### PR TITLE
Implement pod disruptor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,15 +15,18 @@ format:
 test:
 	go test -race  ./...
 
+e2e-api: agent-image
+	go test -tags e2e ./e2e/api/...
+
+e2e-cluster:
+	go test -tags e2e ./e2e/cluster/...
+
 e2e-http: agent-image
 	go test -tags e2e ./e2e/disruptors/http/...
 
 e2e-kubernetes:
 	go test -tags e2e ./e2e/kubernetes/...
 
-e2e-cluster:
-	go test -tags e2e ./e2e/cluster/...
+e2e: e2e-cluster e2e-kubernetes e2e-http e2e-api
 
-e2e: e2e-cluster e2e-kubernetes e2e-http
-
-.PHONY: agent-image build-agent clean e2e e2e-cluster e2e-http e2e-kubernetes format test
+.PHONY: agent-image build-agent clean e2e e2e-api e2e-cluster e2e-http e2e-kubernetes format test

--- a/e2e/api/pod_e2e_test.go
+++ b/e2e/api/pod_e2e_test.go
@@ -1,0 +1,176 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/grafana/xk6-disruptor/pkg/api/disruptors"
+	"github.com/grafana/xk6-disruptor/pkg/kubernetes"
+	"github.com/grafana/xk6-disruptor/pkg/testutils/cluster"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const clusterName = "e2e-pod-disruptor"
+
+// deploy pod with httpbin
+const podManifest = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: httpbin
+  namespace: %s
+  labels:
+    app: httpbin
+spec:
+  containers:
+  - name: httpbin
+    image: kennethreitz/httpbin
+`
+
+// expose httpbin pod at the node port 32080
+const serviceManifest = `
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin
+  namespace: %s
+spec:
+  type: NodePort
+  ports:
+  - name: "http"
+    port: 80
+    nodePort: 32080
+    targetPort: 80
+  selector:
+    app: httpbin
+`
+
+// path to kubeconfig file for the test cluster
+var kubeconfig string
+
+func TestMain(m *testing.M) {
+	// Create cluster that exposes the cluster node port 32080 to the local (host) port 9080
+	fmt.Printf("creating cluster '%s'\n", clusterName)
+	config, err := cluster.NewClusterConfig(
+		clusterName,
+		cluster.ClusterOptions{
+			NodePorts: []cluster.NodePort{
+				{
+					NodePort: 32080,
+					HostPort: 32080,
+				},
+			},
+			Images: []string{"grafana/xk6-disruptor-agent"},
+			Wait:   time.Second * 60,
+		},
+	)
+	if err != nil {
+		fmt.Printf("failed to create cluster config: %v", err)
+		os.Exit(1)
+	}
+
+	cluster, err := config.Create()
+	if err != nil {
+		fmt.Printf("failed to create cluster: %v", err)
+		os.Exit(1)
+	}
+
+	// retrieve path to kubeconfig
+	kubeconfig, _ = cluster.Kubeconfig()
+
+	// run tests
+	rc := m.Run()
+
+	// clean up
+	cluster.Delete()
+
+	os.Exit(rc)
+}
+
+func Test_Error500(t *testing.T) {
+	k8s, err := kubernetes.NewFromKubeconfig(kubeconfig)
+	if err != nil {
+		t.Errorf("error creating kubernetes client: %v", err)
+		return
+	}
+
+	ns, err := k8s.Helpers().CreateRandomNamespace("test-pods")
+	if err != nil {
+		t.Errorf("error creating test namespace: %v", err)
+		return
+	}
+	defer k8s.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+
+	manifest := fmt.Sprintf(podManifest, ns)
+	err = k8s.Create(manifest)
+	if err != nil {
+		t.Errorf("failed to create pod: %v", err)
+		return
+	}
+
+	manifest = fmt.Sprintf(serviceManifest, ns)
+	err = k8s.Create(manifest)
+	if err != nil {
+		t.Errorf("failed to create service: %v", err)
+		return
+	}
+
+	// wait for the service to be ready for accepting requests
+	err = k8s.NamespacedHelpers(ns).WaitServiceReady("httpbin", time.Second*20)
+	if err != nil {
+		t.Errorf("error waiting for service httpbin: %v", err)
+		return
+	}
+
+	// create pod disruptor
+	selector := disruptors.PodSelector{
+		Namespace: ns,
+		Select: disruptors.PodAttributes{
+			Labels: map[string]string{
+				"app": "httpbin",
+			},
+		},
+	}
+	disruptor, err := disruptors.NewPodDisruptor(k8s, selector)
+	if err != nil {
+		t.Errorf("error creating selector: %v", err)
+		return
+	}
+
+	go func() {
+		// apply httpfailure
+		fault := disruptors.HttpFault{
+			ErrorRate: 1.0,
+			ErrorCode: 500,
+		}
+		opts := disruptors.HttpDisruptionOptions{
+			TargetPort: 80,
+			ProxyPort:  8080,
+		}
+		err := disruptor.InjectHttpFaults(fault, 10*time.Second, opts)
+		if err != nil {
+			t.Errorf("error injecting fault: %v", err)
+		}
+	}()
+
+	time.Sleep(2 * time.Second)
+
+	// access service using the local port on which the service was exposed (see ClusterOptions)
+	resp, err := http.Get("http://127.0.0.1:32080")
+	if err != nil {
+		t.Errorf("failed to access service: %v", err)
+		return
+	}
+
+	if resp.StatusCode != 500 {
+		t.Errorf("expected status code 500 but %d received:", resp.StatusCode)
+		return
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/moby/spdystream v0.2.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.sum
+++ b/go.sum
@@ -216,6 +216,7 @@ github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJ
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=

--- a/pkg/api/disruptors/faults.go
+++ b/pkg/api/disruptors/faults.go
@@ -1,0 +1,16 @@
+// Package types defines the types supported by the API.
+package disruptors
+
+// HttpFault specifies a f to be injected in http requests
+type HttpFault struct {
+	// Average delay introduced to requests
+	AverageDelay uint
+	// Variation in the delay (with respect of the average delay)
+	DelayVariation uint
+	// Fraction (in the range 0.0 to 1.0) of requests that will return an error
+	ErrorRate float32
+	// Error code to be returned by requests selected in the error rate
+	ErrorCode uint
+	// List of url paths to be excluded from disruptions
+	Excluded []string
+}

--- a/pkg/api/disruptors/pod.go
+++ b/pkg/api/disruptors/pod.go
@@ -1,0 +1,115 @@
+// Package disruptors implements an API for disrupting targets
+package disruptors
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/grafana/xk6-disruptor/pkg/kubernetes"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+)
+
+// PodAttributes defines the attributes a Pod must match for being selected/excluded
+type PodAttributes struct {
+	Labels map[string]string
+}
+
+// PodSelector defines the criteria for selecting a pod for disruption
+type PodSelector struct {
+	Namespace string
+	// Select Pods that match these PodAttributes
+	Select PodAttributes
+	// Select Pods that match these PodAttributes
+	Exclude PodAttributes
+}
+
+// PodDisruptor defines the types of faults that can be injected in a Pod
+type PodDisruptor interface {
+	// Targets returns the list of targets for the disruptor
+	Targets() ([]string, error)
+}
+
+// podDisruptor is an instance of a PodDisruptor initialized with a list ot target pods
+type podDisruptor struct {
+	selector PodSelector
+	k8s      kubernetes.Kubernetes
+	targets  []string
+}
+
+// buildLabelSelector builds a label selector to be used in the k8s api, from a PodSelector
+func (s *PodSelector) buildLabelSelector() (labels.Selector, error) {
+	labelsSelector := labels.NewSelector()
+	for label, value := range s.Select.Labels {
+		req, err := labels.NewRequirement(label, selection.Equals, []string{value})
+		if err != nil {
+			return nil, err
+		}
+		labelsSelector = labelsSelector.Add(*req)
+	}
+
+	for label, value := range s.Exclude.Labels {
+		req, err := labels.NewRequirement(label, selection.NotEquals, []string{value})
+		if err != nil {
+			return nil, err
+		}
+		labelsSelector = labelsSelector.Add(*req)
+	}
+
+	return labelsSelector, nil
+}
+
+// getTargets retrieves the names of the targets of the disruptor
+func (s *PodSelector) GetTargets(k8s kubernetes.Kubernetes) ([]string, error) {
+	namespace := s.Namespace
+	if namespace == "" {
+		namespace = metav1.NamespaceDefault
+	}
+
+	labelSelector, err := s.buildLabelSelector()
+	if err != nil {
+		return nil, err
+	}
+
+	listOptions := metav1.ListOptions{
+		LabelSelector: labelSelector.String(),
+	}
+	pods, err := k8s.CoreV1().Pods(namespace).List(
+		context.TODO(),
+		listOptions,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if len(pods.Items) == 0 {
+		return nil, fmt.Errorf("no pods match the selector")
+	}
+
+	podNames := []string{}
+	for _, pod := range pods.Items {
+		podNames = append(podNames, pod.Name)
+	}
+
+	return podNames, nil
+}
+
+// NewPodDisruptor creates a new instance of a PodDisruptor that acts on the pods
+// that match the given PodSelector
+func NewPodDisruptor(k8s kubernetes.Kubernetes, selector PodSelector) (PodDisruptor, error) {
+	targets, err := selector.GetTargets(k8s)
+	if err != nil {
+		return nil, err
+	}
+
+	return &podDisruptor{
+		selector: selector,
+		k8s:      k8s,
+		targets:  targets,
+	}, nil
+}
+
+// Targets retrieves the list of target pods for the given PodSelector
+func (d *podDisruptor) Targets() ([]string, error) {
+	return d.targets, nil
+}

--- a/pkg/api/disruptors/pod.go
+++ b/pkg/api/disruptors/pod.go
@@ -4,8 +4,11 @@ package disruptors
 import (
 	"context"
 	"fmt"
+	"sync"
+	"time"
 
 	"github.com/grafana/xk6-disruptor/pkg/kubernetes"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -33,9 +36,10 @@ type PodDisruptor interface {
 
 // podDisruptor is an instance of a PodDisruptor initialized with a list ot target pods
 type podDisruptor struct {
-	selector PodSelector
-	k8s      kubernetes.Kubernetes
-	targets  []string
+	selector   PodSelector
+	controller AgentController
+	k8s        kubernetes.Kubernetes
+	targets    []string
 }
 
 // buildLabelSelector builds a label selector to be used in the k8s api, from a PodSelector
@@ -94,6 +98,56 @@ func (s *PodSelector) GetTargets(k8s kubernetes.Kubernetes) ([]string, error) {
 	return podNames, nil
 }
 
+// agentController controls de agents in a set of target pods
+type AgentController struct {
+	k8s       kubernetes.Kubernetes
+	namespace string
+	targets   []string
+	timeout   time.Duration
+}
+
+// InjectDisruptorAgent injects the Disruptor agent in the target pods
+func (c *AgentController) InjectDisruptorAgent() error {
+	agentContainer := corev1.EphemeralContainer{
+		EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+			Name:  "xk6-agent",
+			Image: "grafana/xk6-disruptor-agent",
+			TTY:   true,
+			Stdin: true,
+		},
+	}
+
+	var wg sync.WaitGroup
+	// ensure errors channel has enough space to avoid blocking gorutines
+	errors := make(chan error, len(c.targets))
+	for _, pod := range c.targets {
+		wg.Add(1)
+		// attach each container asynchronously
+		go func(pod string) {
+			err := c.k8s.NamespacedHelpers(c.namespace).AttachEphemeralContainer(
+				pod,
+				agentContainer,
+				c.timeout,
+			)
+
+			if err != nil {
+				errors <- err
+			}
+
+			wg.Done()
+		}(pod)
+	}
+
+	wg.Wait()
+
+	select {
+	case err := <-errors:
+		return err
+	default:
+		return nil
+	}
+}
+
 // NewPodDisruptor creates a new instance of a PodDisruptor that acts on the pods
 // that match the given PodSelector
 func NewPodDisruptor(k8s kubernetes.Kubernetes, selector PodSelector) (PodDisruptor, error) {
@@ -102,10 +156,22 @@ func NewPodDisruptor(k8s kubernetes.Kubernetes, selector PodSelector) (PodDisrup
 		return nil, err
 	}
 
+	controller := AgentController{
+		k8s:       k8s,
+		namespace: selector.Namespace,
+		targets:   targets,
+		timeout:   10 * time.Second, // FIXME: take from some configuration
+	}
+	err = controller.InjectDisruptorAgent()
+	if err != nil {
+		return nil, err
+	}
+
 	return &podDisruptor{
-		selector: selector,
-		k8s:      k8s,
-		targets:  targets,
+		selector:   selector,
+		controller: controller,
+		k8s:        k8s,
+		targets:    targets,
 	}, nil
 }
 

--- a/pkg/api/disruptors/pod_test.go
+++ b/pkg/api/disruptors/pod_test.go
@@ -1,0 +1,210 @@
+package disruptors
+
+import (
+	"sort"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/grafana/xk6-disruptor/pkg/kubernetes"
+	"github.com/grafana/xk6-disruptor/pkg/testutils/kubernetes/builders"
+)
+
+const testNamespace = "default"
+
+var (
+	podWithoutLabels = builders.NewPodBuilder("pod-without-labels").
+		WithNamespace(testNamespace).
+		WithLabels(map[string]string{}).
+		Build()
+
+	podWithAppLabel = builders.NewPodBuilder("pod-with-app-label").
+		WithNamespace(testNamespace).
+		WithLabels(map[string]string{
+			"app": "test",
+		}).
+		Build()
+
+	podWithAppLabelInAnotherNs = builders.NewPodBuilder("pod-with-app-label").
+		WithNamespace("anotherNamespace").
+		WithLabels(map[string]string{
+			"app": "test",
+		}).
+		Build()
+
+	anotherPodWithAppLabel = builders.NewPodBuilder("another-pod-with-app-label").
+		WithNamespace(testNamespace).
+		WithLabels(map[string]string{
+			"app": "test",
+		}).
+		Build()
+
+	podWithProdEnvLabel = builders.NewPodBuilder("pod-with-prod-label").
+		WithNamespace(testNamespace).
+		WithLabels(map[string]string{
+			"app": "test",
+			"env": "prod",
+		}).
+		Build()
+
+	podWithDevEnvLabel = builders.NewPodBuilder("pod-with-dev-label").
+		WithNamespace(testNamespace).
+		WithLabels(map[string]string{
+			"app": "test",
+			"env": "dev",
+		}).
+		Build()
+)
+
+func compareSortedArrays(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	if len(a) == 0 {
+		return true
+	}
+
+	for i := 0; i < len(a); i++ {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func Test_PodSelectorWithLabels(t *testing.T) {
+	testCases := []struct {
+		title        string
+		pods         []runtime.Object
+		labels       map[string]string
+		exclude      map[string]string
+		expectError  bool
+		expectedPods []string
+	}{
+		{
+			title: "No matching pod",
+			pods: []runtime.Object{
+				podWithoutLabels,
+			},
+			labels: map[string]string{
+				"app": "test",
+			},
+			expectError:  true,
+			expectedPods: []string{},
+		},
+		{
+			title: "No matching namespace",
+			pods: []runtime.Object{
+				podWithAppLabelInAnotherNs,
+			},
+			labels: map[string]string{
+				"app": "test",
+			},
+			expectError:  true,
+			expectedPods: []string{},
+		},
+		{
+			title: "one matching pod",
+			pods: []runtime.Object{
+				podWithAppLabel,
+			},
+			labels: map[string]string{
+				"app": "test",
+			},
+			expectError: false,
+			expectedPods: []string{
+				podWithAppLabel.Name,
+			},
+		},
+		{
+			title: "multiple matching pods",
+			pods: []runtime.Object{
+				podWithAppLabel,
+				anotherPodWithAppLabel,
+			},
+			labels: map[string]string{
+				"app": "test",
+			},
+			expectError: false,
+			expectedPods: []string{
+				podWithAppLabel.Name,
+				anotherPodWithAppLabel.Name,
+			},
+		},
+		{
+			title: "multiple selector labels",
+			pods: []runtime.Object{
+				podWithAppLabel,
+				podWithDevEnvLabel,
+				podWithProdEnvLabel,
+			},
+			labels: map[string]string{
+				"app": "test",
+				"env": "dev",
+			},
+			expectError: false,
+			expectedPods: []string{
+				podWithDevEnvLabel.Name,
+			},
+		},
+		{
+			title: "exclude environment",
+			pods: []runtime.Object{
+				podWithDevEnvLabel,
+				podWithProdEnvLabel,
+			},
+			labels: map[string]string{
+				"app": "test",
+			},
+			exclude: map[string]string{
+				"env": "prod",
+			},
+			expectError: false,
+			expectedPods: []string{
+				podWithDevEnvLabel.Name,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.title, func(t *testing.T) {
+			client := fake.NewSimpleClientset(tc.pods...)
+			k, _ := kubernetes.NewFakeKubernetes(client)
+			selector := PodSelector{
+				Namespace: testNamespace,
+				Select: PodAttributes{
+					Labels: tc.labels,
+				},
+				Exclude: PodAttributes{
+					Labels: tc.exclude,
+				},
+			}
+
+			targets, err := selector.GetTargets(k)
+			if tc.expectError && err == nil {
+				t.Errorf("should had failed")
+				return
+			}
+
+			if !tc.expectError && err != nil {
+				t.Errorf("failed: %v", err)
+				return
+			}
+
+			if tc.expectError && err != nil {
+				return
+			}
+
+			sort.Strings(tc.expectedPods)
+			sort.Strings(targets)
+			if !compareSortedArrays(tc.expectedPods, targets) {
+				t.Errorf("result does not match expected value. Expected: %s\nActual: %s\n", tc.expectedPods, targets)
+				return
+			}
+		})
+	}
+}
+

--- a/pkg/kubernetes/fake.go
+++ b/pkg/kubernetes/fake.go
@@ -1,0 +1,61 @@
+// Package fake offers a fake implementation of the Kubernetes interface
+package kubernetes
+
+import (
+	"fmt"
+
+	"github.com/grafana/xk6-disruptor/pkg/kubernetes/helpers"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+// FakeKubernetes is a fake implementation of the Kubernetes interface
+type FakeKubernetes struct {
+	*fake.Clientset
+	executor *helpers.FakePodCommandExecutor
+}
+
+// NewFakeKubernetes returns a new fake implementation of Kubernetes from fake Clientset
+func NewFakeKubernetes(clientset *fake.Clientset) (*FakeKubernetes, error) {
+	return &FakeKubernetes{
+		Clientset: clientset,
+		executor:  helpers.NewFakePodCommandExecutor(),
+	}, nil
+}
+
+// Helpers return a instance of FakeHelper
+func (f *FakeKubernetes) Helpers() helpers.Helpers {
+	return helpers.NewFakeHelper(
+		f.Clientset,
+		"default",
+		f.executor,
+	)
+}
+
+// NamespacedHelpers return a instance of FakeHelper for a given namespace
+func (f *FakeKubernetes) NamespacedHelpers(namespace string) helpers.Helpers {
+	return helpers.NewFakeHelper(
+		f.Clientset,
+		namespace,
+		f.executor,
+	)
+}
+
+// GetFakeProcessExecutor returns the FakeProcessExecutor used by the helpers to mock
+// the execution of commands in a Pod
+func (f *FakeKubernetes) GetFakeProcessExecutor() *helpers.FakePodCommandExecutor {
+	return f.executor
+}
+
+func (f *FakeKubernetes) Create(manifest string) error {
+	return fmt.Errorf("operation not supported")
+}
+
+func (f *FakeKubernetes) Get(kind string, name string, namespace string, obj runtime.Object) error {
+	return fmt.Errorf("operation not supported")
+}
+
+func (f *FakeKubernetes) Delete(kind string, name string, namespace string) error {
+	return fmt.Errorf("operation not supported")
+}

--- a/pkg/kubernetes/helpers/fake.go
+++ b/pkg/kubernetes/helpers/fake.go
@@ -1,0 +1,84 @@
+package helpers
+
+import (
+	"context"
+	"sync"
+
+	"k8s.io/client-go/kubernetes"
+)
+
+// Command records the execution of a command in a Pod
+type Command struct {
+	Pod       string
+	Container string
+	Command   []string
+	Stdin     []byte
+}
+
+// PodCommandExecutor mocks the execution of a command in a pod
+// recording the command history and returning a predefined stdout, stderr, and error
+type FakePodCommandExecutor struct {
+	mutex   sync.Mutex
+	history []Command
+	stdout  []byte
+	stderr  []byte
+	err     error
+}
+
+// Exec records the execution of a command and returns the pre-defined
+func (f *FakePodCommandExecutor) Exec(pod string, container string, cmd []string, stdin []byte) ([]byte, []byte, error) {
+	f.mutex.Lock()
+	f.history = append(f.history, Command{
+		Pod:       pod,
+		Container: container,
+		Command:   cmd,
+		Stdin:     stdin,
+	})
+	f.mutex.Unlock()
+
+	return f.stdout, f.stderr, f.err
+}
+
+// SetResult sets the results to be returned for each invocation to the FakePodCommandExecutor
+func (f *FakePodCommandExecutor) SetResult(stdout []byte, stderr []byte, err error) {
+	f.stdout = stdout
+	f.stderr = stderr
+	f.err = err
+}
+
+// GetHistory returns the history of commands executed by the FakePodCommandExecutor
+func (f *FakePodCommandExecutor) GetHistory() []Command {
+	return f.history
+}
+
+// NewFakePodCommandExecutor creates a new instance of FakePodCommandExecutor
+// with default attributes
+func NewFakePodCommandExecutor() *FakePodCommandExecutor {
+	return &FakePodCommandExecutor{}
+}
+
+// fakeHelper is an fake instance of a Helpers. It can delegate to the actual
+// helpers the execution of actions or override them when needed
+type fakeHelper struct {
+	*helpers
+	executor *FakePodCommandExecutor
+}
+
+// NewHelpers creates a set of helpers on the default namespace
+func NewFakeHelper(client kubernetes.Interface, namespace string, executor *FakePodCommandExecutor) Helpers {
+	helpers := &helpers{
+		client:    client,
+		namespace: namespace,
+		ctx:       context.TODO(),
+	}
+
+	return &fakeHelper{
+		helpers,
+		executor,
+	}
+}
+
+// Fakes the execution of a command in a pod
+func (f *fakeHelper) Exec(pod string, container string, command []string, stdin []byte) ([]byte, []byte, error) {
+	return f.executor.Exec(pod, container, command, stdin)
+}

--- a/pkg/kubernetes/helpers/helpers.go
+++ b/pkg/kubernetes/helpers/helpers.go
@@ -5,25 +5,29 @@ import (
 	"context"
 
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 )
 
 // Helpers offers Helper functions grouped by the objects they handle
 type Helpers interface {
 	NamespaceHelper
 	ServiceHelper
+	PodHelper
 }
 
 // helpers struct holds the data required by the helpers
 type helpers struct {
+	config    *rest.Config
 	client    kubernetes.Interface
 	namespace string
 	ctx       context.Context
 }
 
 // NewHelpers creates a set of helpers on the default namespace
-func NewHelper(c kubernetes.Interface, namespace string) Helpers {
+func NewHelper(client kubernetes.Interface, config *rest.Config, namespace string) Helpers {
 	return &helpers{
-		client:    c,
+		client:    client,
+		config:    config,
 		namespace: namespace,
 		ctx:       context.TODO(),
 	}

--- a/pkg/kubernetes/helpers/pods.go
+++ b/pkg/kubernetes/helpers/pods.go
@@ -1,0 +1,129 @@
+package helpers
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+type PodHelper interface {
+	WaitPodRunning(name string, timeout time.Duration) (bool, error)
+	Exec(pod string, container string, command []string, stdin []byte) ([]byte, []byte, error)
+}
+
+// podConditionChecker defines a function that checks if a pod satisfies a condition
+type podConditionChecker func(*corev1.Pod) (bool, error)
+
+// waitForCondition watches a Pod in a namespace until a podConditionChecker is satisfied or a timeout expires
+func (h *helpers) waitForCondition(
+	namespace string,
+	name string,
+	timeout time.Duration,
+	checker podConditionChecker,
+) (bool, error) {
+	selector := fields.Set{
+		"metadata.name": name,
+	}.AsSelector()
+
+	watcher, err := h.client.CoreV1().Pods(namespace).Watch(
+		h.ctx,
+		metav1.ListOptions{
+			FieldSelector: selector.String(),
+		},
+	)
+	if err != nil {
+		return false, err
+	}
+	defer watcher.Stop()
+
+	expired := time.After(timeout)
+	for {
+		select {
+		case <-expired:
+			return false, nil
+		case event := <-watcher.ResultChan():
+			if event.Type == watch.Error {
+				return false, fmt.Errorf("error watching for pod: %v", event.Object)
+			}
+			if event.Type == watch.Modified {
+				pod, isPod := event.Object.(*corev1.Pod)
+				if !isPod {
+					return false, errors.New("received unknown object while watching for pods")
+				}
+				condition, err := checker(pod)
+				if condition || err != nil {
+					return condition, err
+				}
+			}
+		}
+	}
+}
+
+// WaitPodRunning waits for the Pod to be running for up to given timeout and returns a boolean indicating if the status
+// was reached. If the pod is Failed returns error.
+func (h *helpers) WaitPodRunning(name string, timeout time.Duration) (bool, error) {
+	return h.waitForCondition(
+		h.namespace,
+		name,
+		timeout,
+		func(pod *corev1.Pod) (bool, error) {
+			if pod.Status.Phase == corev1.PodFailed {
+				return false, errors.New("pod has failed")
+			}
+			if pod.Status.Phase == corev1.PodRunning {
+				return true, nil
+			}
+			return false, nil
+		},
+	)
+}
+
+// Exec executes a non-interactive command described in options and returns the stdout and stderr outputs
+func (h *helpers) Exec(
+	pod string,
+	container string,
+	command []string,
+	stdin []byte,
+) ([]byte, []byte, error) {
+	req := h.client.CoreV1().RESTClient().
+		Post().
+		Namespace(h.namespace).
+		Resource("pods").
+		Name(pod).
+		SubResource("exec").
+		VersionedParams(&corev1.PodExecOptions{
+			Container: container,
+			Command:   command,
+			Stdin:     true,
+			Stdout:    true,
+			Stderr:    true,
+			TTY:       false,
+		}, scheme.ParameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(h.config, "POST", req.URL())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var stdout, stderr bytes.Buffer
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdin:  bytes.NewReader(stdin),
+		Stdout: &stdout,
+		Stderr: &stderr,
+		Tty:    true,
+	})
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return stdout.Bytes(), stderr.Bytes(), nil
+}

--- a/pkg/kubernetes/helpers/pods_test.go
+++ b/pkg/kubernetes/helpers/pods_test.go
@@ -1,0 +1,127 @@
+package helpers
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/fake"
+	k8stest "k8s.io/client-go/testing"
+)
+
+const (
+	testName      = "pod-test"
+	testNamespace = "ns-test"
+)
+
+// newPod is a helper to build a new Pod instance
+func newPod(name string, namespace string) *corev1.Pod {
+	return &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Pod",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app": "xk6-disruptor/test",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:    "busybox",
+					Image:   "busybox",
+					Command: []string{"sh", "-c", "sleep 300"},
+				},
+			},
+			EphemeralContainers: nil,
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+		},
+	}
+}
+
+// newPodWithStatus is a helper for building Pods with a given Status
+func newPodWithStatus(name string, namespace string, phase corev1.PodPhase) *corev1.Pod {
+	pod := newPod(name, namespace)
+	pod.Status.Phase = phase
+	return pod
+}
+
+func TestPods_Wait(t *testing.T) {
+	t.Parallel()
+	type TestCase struct {
+		test           string
+		name           string
+		status         corev1.PodPhase
+		delay          time.Duration
+		expectError    bool
+		expectedResult bool
+		timeout        time.Duration
+	}
+
+	testCases := []TestCase{
+		{
+			test:           "wait pod running",
+			name:           "pod-running",
+			delay:          1 * time.Second,
+			status:         corev1.PodRunning,
+			expectError:    false,
+			expectedResult: true,
+			timeout:        5 * time.Second,
+		},
+		{
+			test:           "timeout waiting pod running",
+			name:           "pod-running",
+			status:         corev1.PodRunning,
+			delay:          10 * time.Second,
+			expectError:    false,
+			expectedResult: false,
+			timeout:        5 * time.Second,
+		},
+		{
+			test:           "wait failed pod",
+			name:           "pod-running",
+			status:         corev1.PodFailed,
+			delay:          1 * time.Second,
+			expectError:    true,
+			expectedResult: false,
+			timeout:        5 * time.Second,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.test, func(t *testing.T) {
+			client := fake.NewSimpleClientset()
+			watcher := watch.NewRaceFreeFake()
+			client.PrependWatchReactor("pods", k8stest.DefaultWatchReactor(watcher, nil))
+			h := NewHelper(client, nil, testNamespace)
+			go func(tc TestCase) {
+				time.Sleep(tc.delay)
+				watcher.Modify(newPodWithStatus(tc.name, testNamespace, tc.status))
+			}(tc)
+
+			result, err := h.WaitPodRunning(
+				tc.name,
+				tc.timeout,
+			)
+
+			if !tc.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if tc.expectError && err == nil {
+				t.Error("expected an error but none returned")
+				return
+			}
+			if result != tc.expectedResult {
+				t.Errorf("expected result %t but %t returned", tc.expectedResult, result)
+				return
+			}
+		})
+	}
+}

--- a/pkg/kubernetes/helpers/services_test.go
+++ b/pkg/kubernetes/helpers/services_test.go
@@ -164,7 +164,7 @@ func Test_WaitServiceReady(t *testing.T) {
 
 			}(tc)
 
-			h := NewHelper(client, "default")
+			h := NewHelper(client, nil, "default")
 
 			err := h.WaitServiceReady("service", tc.timeout)
 			if !tc.expectError && err != nil {

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -34,6 +34,7 @@ type Kubernetes interface {
 
 // k8s Holds the reference to the helpers for interacting with kubernetes
 type k8s struct {
+	config *rest.Config
 	kubernetes.Interface
 	ctx        context.Context
 	dynamic    dynamic.Interface
@@ -75,6 +76,7 @@ func NewFromKubeconfig(kubeconfig string) (Kubernetes, error) {
 	}
 
 	return &k8s{
+		config:     config,
 		Interface:  client,
 		ctx:        context.TODO(),
 		dynamic:    dynamic,
@@ -163,6 +165,7 @@ func (k *k8s) Delete(kind string, name string, namespace string) error {
 func (k *k8s) Helpers() helpers.Helpers {
 	return helpers.NewHelper(
 		k.Interface,
+		k.config,
 		"default",
 	)
 }
@@ -171,6 +174,7 @@ func (k *k8s) Helpers() helpers.Helpers {
 func (k *k8s) NamespacedHelpers(namespace string) helpers.Helpers {
 	return helpers.NewHelper(
 		k.Interface,
+		k.config,
 		namespace,
 	)
 }

--- a/pkg/testutils/kubernetes/builders/pod.go
+++ b/pkg/testutils/kubernetes/builders/pod.go
@@ -1,0 +1,78 @@
+// Package builders offers functions for building test objects
+package builders
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type PodBuilder interface {
+	// Build returns a Pod with the attributes defined in the PodBuilder
+	Build() *corev1.Pod
+	// WithNamespace sets namespace for the pod to be built
+	WithNamespace(namespace string) PodBuilder
+	// WithLabels sets the labels for the pod to be built
+	WithLabels(labels map[string]string) PodBuilder
+	// WithStatus sets the PodPhase for the pod  to be built
+	WithStatus(status corev1.PodPhase) PodBuilder
+}
+
+// podBuilder defines the attributes for building a pod
+type podBuilder struct {
+	name       string
+	namespace  string
+	labels     map[string]string
+	status     corev1.PodPhase
+	containers []corev1.Container
+}
+
+// NewPodBuilder creates a new instance of NewPodBuilder with the given pod name
+// and default attributes such as containers and namespace
+func NewPodBuilder(name string) *podBuilder {
+	return &podBuilder{
+		name: name,
+		containers: []corev1.Container{
+			{
+				Name:    "busybox",
+				Image:   "busybox",
+				Command: []string{"sh", "-c", "sleep 300"},
+			},
+		},
+	}
+}
+
+func (b *podBuilder) WithNamespace(namespace string) PodBuilder {
+	b.namespace = namespace
+	return b
+}
+
+func (b *podBuilder) WithStatus(phase corev1.PodPhase) PodBuilder {
+	b.status = phase
+	return b
+}
+
+func (b *podBuilder) WithLabels(labels map[string]string) PodBuilder {
+	b.labels = labels
+	return b
+}
+
+func (b *podBuilder) Build() *corev1.Pod {
+	return &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Pod",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      b.name,
+			Namespace: b.namespace,
+			Labels:    b.labels,
+		},
+		Spec: corev1.PodSpec{
+			Containers:          b.containers,
+			EphemeralContainers: nil,
+		},
+		Status: corev1.PodStatus{
+			Phase: b.status,
+		},
+	}
+}


### PR DESCRIPTION
This change set implements an API for creating PodDisruptors. A PodDisruptor selects a group of target pods based on a selection criteria (at this point, only labels) and injects the xk6-disruptor agent as an ephemeral container. Once the agent is injected in the targets, the PodDisruptor is capable of injecting faults. In this implementation the only fault implemented is the http fault. 