### PR TITLE
Remove generic K8s API

### DIFF
--- a/pkg/kubernetes/fake.go
+++ b/pkg/kubernetes/fake.go
@@ -3,11 +3,9 @@ package kubernetes
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/grafana/xk6-disruptor/pkg/kubernetes/helpers"
 
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -22,15 +20,16 @@ type FakeKubernetes struct {
 func NewFakeKubernetes(clientset *fake.Clientset) (*FakeKubernetes, error) {
 	return &FakeKubernetes{
 		Clientset: clientset,
-		ctx: context.TODO(),
+		ctx:       context.TODO(),
 		executor:  helpers.NewFakePodCommandExecutor(),
 	}, nil
 }
 
 // Returns the context for executing k8s actions
-func (k *FakeKubernetes)Context() context.Context {
+func (k *FakeKubernetes) Context() context.Context {
 	return k.ctx
 }
+
 // Helpers return a instance of FakeHelper
 func (f *FakeKubernetes) Helpers() helpers.Helpers {
 	return helpers.NewFakeHelper(
@@ -53,16 +52,4 @@ func (f *FakeKubernetes) NamespacedHelpers(namespace string) helpers.Helpers {
 // the execution of commands in a Pod
 func (f *FakeKubernetes) GetFakeProcessExecutor() *helpers.FakePodCommandExecutor {
 	return f.executor
-}
-
-func (f *FakeKubernetes) Create(manifest string) error {
-	return fmt.Errorf("operation not supported")
-}
-
-func (f *FakeKubernetes) Get(kind string, name string, namespace string, obj runtime.Object) error {
-	return fmt.Errorf("operation not supported")
-}
-
-func (f *FakeKubernetes) Delete(kind string, name string, namespace string) error {
-	return fmt.Errorf("operation not supported")
 }

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -7,28 +7,16 @@ import (
 
 	"github.com/grafana/xk6-disruptor/pkg/kubernetes/helpers"
 
-	apimeta "k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-// Defines an interface that extends kubernetes interface[k8s.io/client-go/kubernetes.Interface] adding
-// generic functions that operate on any kind of object
+// Defines an interface that extends kubernetes interface[k8s.io/client-go/kubernetes.Interface]
+// Adding helper functions for common tasks
 type Kubernetes interface {
 	kubernetes.Interface
 	Context() context.Context
-	Create(manifest string) error
-	Get(kind string, name string, namespace string, obj runtime.Object) error
-	Delete(kind string, name string, namespace string) error
 	Helpers() helpers.Helpers
 	NamespacedHelpers(namespace string) helpers.Helpers
 }
@@ -45,21 +33,7 @@ type KubernetesConfig struct {
 type k8s struct {
 	config *rest.Config
 	kubernetes.Interface
-	ctx        context.Context
-	dynamic    dynamic.Interface
-	serializer runtime.Serializer
-	mapper     apimeta.RESTMapper
-}
-
-// getRestMapper returns a mapper that allows mapping object types to api resources
-func getRestMapper(client kubernetes.Interface, config *rest.Config) (apimeta.RESTMapper, error) {
-	gr, err := restmapper.GetAPIGroupResources(client.Discovery())
-	if err != nil {
-		return nil, err
-	}
-
-	mapper := restmapper.NewDiscoveryRESTMapper(gr)
-	return mapper, nil
+	ctx context.Context
 }
 
 // NewFromKubeconfig returns a Kubernetes instance configured with the kubeconfig pointed by the given path
@@ -69,24 +43,14 @@ func NewFromKubeconfig(kubeconfig string) (Kubernetes, error) {
 	})
 }
 
-// NewFromConfig returns a Kubernetes instance
+// NewFromConfig returns a Kubernetes instance configured with the given options
 func NewFromConfig(c KubernetesConfig) (Kubernetes, error) {
 	config, err := clientcmd.BuildConfigFromFlags("", c.Kubeconfig)
 	if err != nil {
 		return nil, err
 	}
 
-	dynamic, err := dynamic.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-
 	client, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-
-	mapper, err := getRestMapper(client, config)
 	if err != nil {
 		return nil, err
 	}
@@ -97,94 +61,15 @@ func NewFromConfig(c KubernetesConfig) (Kubernetes, error) {
 	}
 
 	return &k8s{
-		config:     config,
-		Interface:  client,
-		ctx:        ctx,
-		dynamic:    dynamic,
-		serializer: yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme),
-		mapper:     mapper,
+		config:    config,
+		Interface: client,
+		ctx:       ctx,
 	}, nil
 }
 
 // Returns the context for executing k8s actions
-func (k *k8s)Context() context.Context {
+func (k *k8s) Context() context.Context {
 	return k.ctx
-}
-
-// Create creates a resource in a kubernetes cluster from a yaml manifest
-func (k *k8s) Create(manifest string) error {
-	uObj := &unstructured.Unstructured{}
-	_, gvk, err := k.serializer.Decode([]byte(manifest), nil, uObj)
-	if err != nil {
-		return err
-	}
-
-	namespace := uObj.GetNamespace()
-	if namespace == "" {
-		namespace = "default"
-	}
-	mapping, err := k.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
-	if err != nil {
-		return err
-	}
-
-	_, err = k.dynamic.Resource(mapping.Resource).
-		Namespace(namespace).
-		Create(
-			k.ctx,
-			uObj,
-			metav1.CreateOptions{},
-		)
-
-	return err
-}
-
-// Get returns an object given its kind, name and namespace. The object is returned in the runtime
-// object passed as parameter.
-// Example:
-//    pod := corev1.Pod{}
-//    err := k8s.Get("Pod", "podname", "namespace", &pod)
-func (k *k8s) Get(kind string, name string, namespace string, obj runtime.Object) error {
-
-	gvk := schema.GroupKind{Kind: kind}
-
-	mapping, err := k.mapper.RESTMapping(gvk)
-	if err != nil {
-		return err
-	}
-
-	resp, err := k.dynamic.
-		Resource(mapping.Resource).
-		Namespace(namespace).
-		Get(k.ctx, name, metav1.GetOptions{})
-
-	if err != nil {
-		return err
-	}
-
-	//convert the unstructured object to a runtime object
-	uObj := resp.UnstructuredContent()
-	err = runtime.DefaultUnstructuredConverter.FromUnstructured(uObj, obj)
-
-	return err
-}
-
-// Delete deletes an object given its kind, name and namespace
-func (k *k8s) Delete(kind string, name string, namespace string) error {
-
-	gvk := schema.GroupKind{Kind: kind}
-
-	mapping, err := k.mapper.RESTMapping(gvk)
-	if err != nil {
-		return err
-	}
-
-	err = k.dynamic.
-		Resource(mapping.Resource).
-		Namespace(namespace).
-		Delete(k.ctx, name, metav1.DeleteOptions{})
-
-	return err
 }
 
 // Helpers returns Helpers for the default namespace


### PR DESCRIPTION
Remove from the xk6-disruptor extension generic Kubernetes functionality [that will be provided by the xk6-kubernetes extension](https://github.com/grafana/xk6-kubernetes/pull/70).

Signed-off-by: Pablo Chacin <pablochacin@gmail.com>