### PR TITLE
Refactor e2e tests

### DIFF
--- a/e2e/api/pod_e2e_test.go
+++ b/e2e/api/pod_e2e_test.go
@@ -5,203 +5,99 @@ package e2e
 
 import (
 	"context"
-	"fmt"
-	"net/http"
-	"os"
 	"testing"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/grafana/xk6-disruptor/pkg/api/disruptors"
 	"github.com/grafana/xk6-disruptor/pkg/kubernetes"
-	"github.com/grafana/xk6-disruptor/pkg/testutils/cluster"
-
+	"github.com/grafana/xk6-disruptor/pkg/testutils/e2e/checks"
+	"github.com/grafana/xk6-disruptor/pkg/testutils/e2e/fixtures"
 )
 
-const clusterName = "e2e-pod-disruptor"
-
-func buildHttpbinPod() *corev1.Pod {
-	return &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "httpbin",
-			Labels: map[string]string{
-				"app": "httpbin",
-			},
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name:            "httpbin",
-					Image:           "kennethreitz/httpbin",
-					ImagePullPolicy: corev1.PullIfNotPresent,
-				},
-			},
-		},
-	}
-}
-
-// expose ngix pod at the node port 32080
-func buildHttpbinService() *corev1.Service {
-	return &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "httpbin",
-			Labels: map[string]string{
-				"app": "httpbin",
-			},
-		},
-		Spec: corev1.ServiceSpec{
-			Type: corev1.ServiceTypeNodePort,
-			Selector: map[string]string{
-				"app": "httpbin",
-			},
-			Ports: []corev1.ServicePort{
-				{
-					Name:     "http",
-					Port:     80,
-					NodePort: 32080,
-				},
-			},
-		},
-	}
-}
-
-
-// path to kubeconfig file for the test cluster
-var kubeconfig string
-
-func TestMain(m *testing.M) {
-	// Create cluster that exposes the cluster node port 32080 to the local (host) port 9080
-	fmt.Printf("creating cluster '%s'\n", clusterName)
-	config, err := cluster.NewClusterConfig(
-		clusterName,
-		cluster.ClusterOptions{
-			NodePorts: []cluster.NodePort{
-				{
-					NodePort: 32080,
-					HostPort: 32080,
-				},
-			},
-			Images: []string{"grafana/xk6-disruptor-agent"},
-			Wait:   time.Second * 60,
-		},
-	)
+func Test_PodDisruptor(t *testing.T) {
+	cluster, err := fixtures.BuildCluster("e2e-pod-disruptor")
 	if err != nil {
-		fmt.Printf("failed to create cluster config: %v", err)
-		os.Exit(1)
+		t.Errorf("failed to create cluster config: %v", err)
+		return
 	}
+	defer cluster.Delete()
 
-	cluster, err := config.Create()
-	if err != nil {
-		fmt.Printf("failed to create cluster: %v", err)
-		os.Exit(1)
-	}
-
-	// retrieve path to kubeconfig
-	kubeconfig  = cluster.Kubeconfig()
-
-	// run tests
-	rc := m.Run()
-
-	// clean up
-	cluster.Delete()
-
-	os.Exit(rc)
-}
-
-func Test_Error500(t *testing.T) {
-	k8s, err := kubernetes.NewFromKubeconfig(kubeconfig)
+	k8s, err := kubernetes.NewFromKubeconfig(cluster.Kubeconfig())
 	if err != nil {
 		t.Errorf("error creating kubernetes client: %v", err)
 		return
 	}
 
-	ns, err := k8s.Helpers().CreateRandomNamespace("test-pods")
-	if err != nil {
-		t.Errorf("error creating test namespace: %v", err)
-		return
-	}
-	defer k8s.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-
-	_, err = k8s.CoreV1().Pods(ns).Create(
-		context.TODO(),
-		buildHttpbinPod(),
-		metav1.CreateOptions{},
-	)
-	if err != nil {
-		t.Errorf("failed to create pod: %v", err)
-		return
-	}
-
-	_, err = k8s.CoreV1().Services(ns).Create(
-		context.TODO(),
-		buildHttpbinService(),
-		metav1.CreateOptions{},
-	)
-	if err != nil {
-		t.Errorf("failed to create service: %v", err)
-		return
-	}
-
-	// wait for the service to be ready for accepting requests
-	err = k8s.NamespacedHelpers(ns).WaitServiceReady("httpbin", time.Second*20)
-	if err != nil {
-		t.Errorf("error waiting for service httpbin: %v", err)
-		return
-	}
-
-	// create pod disruptor
-	selector := disruptors.PodSelector{
-		Namespace: ns,
-		Select: disruptors.PodAttributes{
-			Labels: map[string]string{
-				"app": "httpbin",
-			},
-		},
-	}
-	options := disruptors.PodDisruptorOptions{
-		InjectTimeout: 10,
-	}
-	disruptor, err := disruptors.NewPodDisruptor(k8s, selector, options)
-	if err != nil {
-		t.Errorf("error creating selector: %v", err)
-		return
-	}
-
-	targets, _ := disruptor.Targets()
-	if len(targets) == 0 {
-		t.Errorf("No pods matched the selector")
-		return
-	}
-
-	go func() {
-		// apply httpfailure
-		fault := disruptors.HttpFault{
-			ErrorRate: 1.0,
-			ErrorCode: 500,
-		}
-		opts := disruptors.HttpDisruptionOptions{
-			TargetPort: 80,
-			ProxyPort:  8080,
-		}
-		err := disruptor.InjectHttpFaults(fault, 10, opts)
+	t.Run("Inject Http error 500", func(t *testing.T) {
+		ns, err := k8s.Helpers().CreateRandomNamespace("test-pods")
 		if err != nil {
-			t.Errorf("error injecting fault: %v", err)
+			t.Errorf("error creating test namespace: %v", err)
+			return
 		}
-	}()
+		defer k8s.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
 
-	time.Sleep(2 * time.Second)
+		err = fixtures.DeployApp(
+			k8s,
+			ns,
+			fixtures.BuildHttpbinPod(),
+			fixtures.BuildHttpbinService(),
+			20*time.Second,
+		)
+		if err != nil {
+			t.Errorf("error deploying httpbin: %v", err)
+			return
+		}
 
-	// access service using the local port on which the service was exposed (see ClusterOptions)
-	resp, err := http.Get("http://127.0.0.1:32080")
-	if err != nil {
-		t.Errorf("failed to access service: %v", err)
-		return
-	}
+		// create pod disruptor
+		selector := disruptors.PodSelector{
+			Namespace: ns,
+			Select: disruptors.PodAttributes{
+				Labels: map[string]string{
+					"app": "httpbin",
+				},
+			},
+		}
+		options := disruptors.PodDisruptorOptions{
+			InjectTimeout: 10,
+		}
+		disruptor, err := disruptors.NewPodDisruptor(k8s, selector, options)
+		if err != nil {
+			t.Errorf("error creating selector: %v", err)
+			return
+		}
 
-	if resp.StatusCode != 500 {
-		t.Errorf("expected status code 500 but %d received:", resp.StatusCode)
-		return
-	}
+		targets, _ := disruptor.Targets()
+		if len(targets) == 0 {
+			t.Errorf("No pods matched the selector")
+			return
+		}
+
+		// apply disruption in a go-routine as it is a blocking function
+		go func() {
+			// apply httpfailure
+			fault := disruptors.HttpFault{
+				ErrorRate: 1.0,
+				ErrorCode: 500,
+			}
+			opts := disruptors.HttpDisruptionOptions{
+				TargetPort: 80,
+				ProxyPort:  8080,
+			}
+			err := disruptor.InjectHttpFaults(fault, 10, opts)
+			if err != nil {
+				t.Errorf("error injecting fault: %v", err)
+			}
+		}()
+
+		err = checks.CheckService(checks.ServiceCheck{
+			Delay:        2 * time.Second,
+			ExpectedCode: 500,
+		})
+		if err != nil {
+			t.Errorf("failed to access service: %v", err)
+			return
+		}
+	})
 }

--- a/e2e/api/pod_e2e_test.go
+++ b/e2e/api/pod_e2e_test.go
@@ -99,7 +99,7 @@ func TestMain(m *testing.M) {
 	}
 
 	// retrieve path to kubeconfig
-	kubeconfig, _ = cluster.Kubeconfig()
+	kubeconfig  = cluster.Kubeconfig()
 
 	// run tests
 	rc := m.Run()

--- a/e2e/cluster/cluster_e2e_test.go
+++ b/e2e/cluster/cluster_e2e_test.go
@@ -102,11 +102,7 @@ func Test_PreloadImages(t *testing.T) {
 
 	defer cluster.Delete()
 
-	kubeconfig, err := cluster.Kubeconfig()
-	if err != nil {
-		t.Errorf("failed to retrieve kubeconfig: %v", err)
-		return
-	}
+	kubeconfig := cluster.Kubeconfig()
 
 	k8s, err := getKubernetesClient(kubeconfig)
 	if err != nil {

--- a/e2e/cluster/cluster_e2e_test.go
+++ b/e2e/cluster/cluster_e2e_test.go
@@ -73,7 +73,6 @@ func buildBusyboxPod() *corev1.Pod {
 }
 
 func Test_PreloadImages(t *testing.T) {
-
 	// ensure image is available locally
 	output, err := exec.Command("docker", "pull", "busybox").CombinedOutput()
 	if err != nil {

--- a/e2e/disruptors/http/http_e2e_test.go
+++ b/e2e/disruptors/http/http_e2e_test.go
@@ -123,7 +123,7 @@ func TestMain(m *testing.M) {
 	}
 
 	// retrieve path to kubeconfig
-	kubeconfig, _ = cluster.Kubeconfig()
+	kubeconfig = cluster.Kubeconfig()
 
 	// run tests
 	rc := m.Run()

--- a/e2e/disruptors/http/http_e2e_test.go
+++ b/e2e/disruptors/http/http_e2e_test.go
@@ -5,20 +5,16 @@ package e2e
 
 import (
 	"context"
-	"fmt"
-	"net/http"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/grafana/xk6-disruptor/pkg/kubernetes"
-	"github.com/grafana/xk6-disruptor/pkg/testutils/cluster"
+	"github.com/grafana/xk6-disruptor/pkg/testutils/e2e/checks"
+	"github.com/grafana/xk6-disruptor/pkg/testutils/e2e/fixtures"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
-
-const clusterName = "e2e-httpdisruptor"
 
 // deploy pod with [httpbin] and the httpdisruptor as sidekick container
 func buildHttpbinPodWithDisruptorAgent() *corev1.Pod {
@@ -67,75 +63,18 @@ func buildHttpbinPodWithDisruptorAgent() *corev1.Pod {
 	}
 }
 
-// expose ngix pod at the node port 32080
-func buildHttpbinService() *corev1.Service {
-	return &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "httpbin",
-			Labels: map[string]string{
-				"app": "httpbin",
-			},
-		},
-		Spec: corev1.ServiceSpec{
-			Type: corev1.ServiceTypeNodePort,
-			Selector: map[string]string{
-				"app": "httpbin",
-			},
-			Ports: []corev1.ServicePort{
-				{
-					Name:     "http",
-					Port:     80,
-					NodePort: 32080,
-				},
-			},
-		},
-	}
-}
+// Test_InjectHttp500 tests in the Httpbin pod by running the xk6-disruptor agent as a sidekick container
+func Test_InjectHttp500(t *testing.T) {
+	t.Parallel()
 
-// path to kubeconfig file for the test cluster
-var kubeconfig string
-
-func TestMain(m *testing.M) {
-	// Create cluster that exposes the cluster node port 32080 to the local (host) port 9080
-	fmt.Printf("creating cluster '%s'\n", clusterName)
-	config, err := cluster.NewClusterConfig(
-		clusterName,
-		cluster.ClusterOptions{
-			NodePorts: []cluster.NodePort{
-				{
-					NodePort: 32080,
-					HostPort: 32080,
-				},
-			},
-			Images: []string{"grafana/xk6-disruptor-agent"},
-			Wait:   time.Second * 60,
-		},
-	)
+	cluster, err := fixtures.BuildCluster("e2e-http-disruptor")
 	if err != nil {
-		fmt.Printf("failed to create cluster config: %v", err)
-		os.Exit(1)
+		t.Errorf("failed to create cluster config: %v", err)
+		return
 	}
+	defer cluster.Delete()
 
-	cluster, err := config.Create()
-	if err != nil {
-		fmt.Printf("failed to create cluster: %v", err)
-		os.Exit(1)
-	}
-
-	// retrieve path to kubeconfig
-	kubeconfig = cluster.Kubeconfig()
-
-	// run tests
-	rc := m.Run()
-
-	// cleanup
-	cluster.Delete()
-
-	os.Exit(rc)
-}
-
-func Test_Error500(t *testing.T) {
-	k8s, err := kubernetes.NewFromKubeconfig(kubeconfig)
+	k8s, err := kubernetes.NewFromKubeconfig(cluster.Kubeconfig())
 	if err != nil {
 		t.Errorf("error creating kubernetes client: %v", err)
 		return
@@ -158,32 +97,18 @@ func Test_Error500(t *testing.T) {
 		return
 	}
 
-	_, err = k8s.CoreV1().Services(ns).Create(
-		context.TODO(),
-		buildHttpbinService(),
-		metav1.CreateOptions{},
-	)
+	err = fixtures.ExposeService(k8s, ns, fixtures.BuildHttpbinService(), 20*time.Second)
 	if err != nil {
 		t.Errorf("failed to create service: %v", err)
 		return
 	}
 
-	// wait for the service to be ready for accepting requests
-	err = k8s.NamespacedHelpers(ns).WaitServiceReady("httpbin", time.Second*30)
-	if err != nil {
-		t.Errorf("error waiting for service httpbin: %v", err)
-		return
-	}
+	err = checks.CheckService(checks.ServiceCheck{
+		ExpectedCode: 500,
+	})
 
-	// access service using the local port on which the service was exposed (see ClusterOptions)
-	resp, err := http.Get("http://127.0.0.1:32080")
 	if err != nil {
-		t.Errorf("failed to access service: %v", err)
-		return
-	}
-
-	if resp.StatusCode != 500 {
-		t.Errorf("expected status code 500 but %d received:", resp.StatusCode)
+		t.Errorf("failed : %v", err)
 		return
 	}
 }

--- a/e2e/kubernetes/kubernetes_e2e_test.go
+++ b/e2e/kubernetes/kubernetes_e2e_test.go
@@ -1,335 +1,184 @@
 //go:build e2e
 // +build e2e
 
-package kubernetes
+package e2e
 
 import (
 	"context"
-	"fmt"
-	"net/http"
-	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/grafana/xk6-disruptor/pkg/kubernetes"
-	"github.com/grafana/xk6-disruptor/pkg/testutils/cluster"
+	"github.com/grafana/xk6-disruptor/pkg/testutils/e2e/checks"
+	"github.com/grafana/xk6-disruptor/pkg/testutils/e2e/fixtures"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const clusterName = "e2e-kubernetes"
-
-var kubeconfig string
-
-func TestMain(m *testing.M) {
-	// create cluster exposing node port 32080 on host port 9080
-	config, err := cluster.NewClusterConfig(
-		clusterName,
-		cluster.ClusterOptions{
-			Wait: time.Second * 60,
-			NodePorts: []cluster.NodePort{
-				{
-					HostPort: 9080,
-					NodePort: 32080,
-				},
-			},
-		},
-	)
+func Test_Kubernetes(t *testing.T) {
+	cluster, err := fixtures.BuildCluster("e2e-kubernetes")
 	if err != nil {
-		fmt.Printf("failed to create cluster config: %v", err)
-		os.Exit(1)
+		t.Errorf("failed to create cluster config: %v", err)
+		return
 	}
+	defer cluster.Delete()
 
-	cluster, err := config.Create()
-	if err != nil {
-		fmt.Printf("failed to create cluster: %v", err)
-		os.Exit(1)
-	}
-
-	// retrieve path to kubeconfig
-	kubeconfig = cluster.Kubeconfig()
-
-	// run tests
-	rc := m.Run()
-
-	// delete cluster
-	cluster.Delete()
-
-	os.Exit(rc)
-}
-
-func buildBusyBoxPod() *corev1.Pod {
-	return &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "busybox",
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name:            "busybox",
-					Image:           "busybox",
-					ImagePullPolicy: corev1.PullIfNotPresent,
-					Command:         []string{"sleep", "300"},
-				},
-			},
-		},
-	}
-}
-
-func buildPausedPod() *corev1.Pod {
-	return &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "paused",
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name:            "paused",
-					Image:           "k8s.gcr.io/pause",
-					ImagePullPolicy: corev1.PullIfNotPresent,
-				},
-			},
-		},
-	}
-}
-
-func buildNginxPod() *corev1.Pod {
-	return &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "nginx",
-			Labels: map[string]string{
-				"app": "e2e-test",
-			},
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{
-				{
-					Name:            "nginx",
-					Image:           "nginx",
-					ImagePullPolicy: corev1.PullIfNotPresent,
-				},
-			},
-		},
-	}
-}
-
-func buildNginxService() *corev1.Service {
-	return &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "nginx",
-			Labels: map[string]string{
-				"app": "e2e-test",
-			},
-		},
-		Spec: corev1.ServiceSpec{
-			Type: corev1.ServiceTypeNodePort,
-			Selector: map[string]string{
-				"app": "e2e-test",
-			},
-			Ports: []corev1.ServicePort{
-				{
-					Name:     "http",
-					Port:     80,
-					NodePort: 32080,
-				},
-			},
-		},
-	}
-}
-
-func Test_WaitServiceReady(t *testing.T) {
-	k8s, err := kubernetes.NewFromKubeconfig(kubeconfig)
+	k8s, err := kubernetes.NewFromKubeconfig(cluster.Kubeconfig())
 	if err != nil {
 		t.Errorf("error creating kubernetes client: %v", err)
 		return
 	}
 
-	ns, err := k8s.Helpers().CreateRandomNamespace("test-")
-	if err != nil {
-		t.Errorf("error creating test namespace: %v", err)
-		return
-	}
-	defer k8s.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+	kubeconfig := cluster.Kubeconfig()
 
-	_, err = k8s.CoreV1().Pods(ns).Create(
-		context.TODO(),
-		buildNginxPod(),
-		metav1.CreateOptions{},
-	)
-	if err != nil {
-		t.Errorf("failed to create pod: %v", err)
-		return
-	}
+	// Test Creating a random namespace
+	t.Run("Create Random Namespace", func(t *testing.T) {
+		k8s, err := kubernetes.NewFromKubeconfig(kubeconfig)
+		if err != nil {
+			t.Errorf("error creating kubernetes client: %v", err)
+			return
+		}
+		prefix := "test"
+		ns, err := k8s.Helpers().CreateRandomNamespace(prefix)
+		if err != nil {
+			t.Errorf("unexpected error creating namespace: %v", err)
+			return
+		}
+		if !strings.HasPrefix(ns, prefix) {
+			t.Errorf("returned namespace does not have expected prefix '%s': %s", prefix, ns)
 
-	_, err = k8s.CoreV1().Services(ns).Create(
-		context.TODO(),
-		buildNginxService(),
-		metav1.CreateOptions{},
-	)
-	if err != nil {
-		t.Errorf("failed to create service: %v", err)
-		return
-	}
+		}
+	})
 
-	// wait for the service to be ready for accepting requests
-	err = k8s.NamespacedHelpers(ns).WaitServiceReady("nginx", time.Second*20)
-	if err != nil {
-		t.Errorf("error waiting for service nginx: %v", err)
-		return
-	}
+	// Test Wait Service Ready helper
+	t.Run("Wait Service Ready", func(t *testing.T) {
+		ns, err := k8s.Helpers().CreateRandomNamespace("test-")
+		if err != nil {
+			t.Errorf("error creating test namespace: %v", err)
+			return
+		}
+		defer k8s.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
 
-	// access service using the local port on which the service was exposed (see ClusterOptions)
-	_, err = http.Get("http://127.0.0.1:9080")
-	if err != nil {
-		t.Errorf("failed to access service: %v", err)
-		return
-	}
-}
+		// Deploy nginx and expose it as a service. Intentionally not using e2e fixures
+		// because these functions rely on WaitPodRunnin and WaitServiceReady which we
+		// are testing here.
+		_, err = k8s.CoreV1().Pods(ns).Create(
+			context.TODO(),
+			fixtures.BuildNginxPod(),
+			metav1.CreateOptions{},
+		)
+		if err != nil {
+			t.Errorf("failed to create pod: %v", err)
+			return
+		}
 
-func Test_CreateRandomNamespace(t *testing.T) {
-	k8s, err := kubernetes.NewFromKubeconfig(kubeconfig)
-	if err != nil {
-		t.Errorf("error creating kubernetes client: %v", err)
-		return
-	}
-	prefix := "test"
-	ns, err := k8s.Helpers().CreateRandomNamespace(prefix)
-	if err != nil {
-		t.Errorf("unexpected error creating namespace: %v", err)
-		return
-	}
-	if !strings.HasPrefix(ns, prefix) {
-		t.Errorf("returned namespace does not have expected prefix '%s': %s", prefix, ns)
+		_, err = k8s.CoreV1().Services(ns).Create(
+			context.TODO(),
+			fixtures.BuildNginxService(),
+			metav1.CreateOptions{},
+		)
+		if err != nil {
+			t.Errorf("failed to create nginx service: %v", err)
+			return
+		}
 
-	}
-}
+		// wait for the service to be ready for accepting requests
+		err = k8s.NamespacedHelpers(ns).WaitServiceReady("nginx", time.Second*20)
+		if err != nil {
+			t.Errorf("error waiting for service nginx: %v", err)
+			return
+		}
 
-func Test_Exec(t *testing.T) {
-	k8s, err := kubernetes.NewFromKubeconfig(kubeconfig)
-	if err != nil {
-		t.Errorf("error creating kubernetes client: %v", err)
-		return
-	}
+		// access service using the local port on which the service was exposed (see ClusterOptions)
+		err = checks.CheckService(checks.ServiceCheck{
 
-	ns, err := k8s.Helpers().CreateRandomNamespace("test-")
-	if err != nil {
-		t.Errorf("error creating test namespace: %v", err)
-		return
-	}
-	defer k8s.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+			ExpectedCode: 200,
+		})
+		if err != nil {
+			t.Errorf("failed to access service: %v", err)
+			return
+		}
+	})
 
-	_, err = k8s.CoreV1().Pods(ns).Create(
-		context.TODO(),
-		buildBusyBoxPod(),
-		metav1.CreateOptions{},
-	)
-	if err != nil {
-		t.Errorf("failed to create pod: %v", err)
-		return
-	}
+	t.Run("Exec Command", func(t *testing.T) {
+		ns, err := k8s.Helpers().CreateRandomNamespace("test-")
+		if err != nil {
+			t.Errorf("error creating test namespace: %v", err)
+			return
+		}
+		defer k8s.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
 
-	timeout := time.Second * 15
-	running, err := k8s.NamespacedHelpers(ns).WaitPodRunning(
-		"busybox",
-		timeout,
-	)
-	if err != nil {
-		t.Errorf("error waiting for pod: %v", err)
-		return
-	}
-	if !running {
-		t.Errorf("pod not ready after %f: ", timeout.Seconds())
-		return
-	}
+		err = fixtures.RunPod(k8s, ns, fixtures.BuildBusyBoxPod(), 10*time.Second)
+		if err != nil {
+			t.Errorf("error creating pod: %v", err)
+			return
+		}
 
-	stdout, _, err := k8s.NamespacedHelpers(ns).Exec(
-		"busybox",
-		"busybox",
-		[]string{"echo", "-n", "hello", "world"},
-		nil,
-	)
-	if err != nil {
-		t.Errorf("error executing command in pod: %v", err)
-		return
-	}
+		stdout, _, err := k8s.NamespacedHelpers(ns).Exec(
+			"busybox",
+			"busybox",
+			[]string{"echo", "-n", "hello", "world"},
+			nil,
+		)
+		if err != nil {
+			t.Errorf("error executing command in pod: %v", err)
+			return
+		}
 
-	greetings := "hello world"
-	if string(stdout) != "hello world" {
-		t.Errorf("stdout does not match expected result:\nexpected: %s\nactual%s\n", greetings, string(stdout))
-		return
-	}
-}
+		greetings := "hello world"
+		if string(stdout) != "hello world" {
+			t.Errorf("stdout does not match expected result:\nexpected: %s\nactual%s\n", greetings, string(stdout))
+			return
+		}
+	})
 
-func Test_AttachEphemeral(t *testing.T) {
-	k8s, err := kubernetes.NewFromKubeconfig(kubeconfig)
-	if err != nil {
-		t.Errorf("error creating kubernetes client: %v", err)
-		return
-	}
+	t.Run("Attach Ephemeral Container", func(t *testing.T) {
+		ns, err := k8s.Helpers().CreateRandomNamespace("test-")
+		if err != nil {
+			t.Errorf("error creating test namespace: %v", err)
+			return
+		}
+		defer k8s.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
 
-	ns, err := k8s.Helpers().CreateRandomNamespace("test-")
-	if err != nil {
-		t.Errorf("error creating test namespace: %v", err)
-		return
-	}
-	defer k8s.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		err = fixtures.RunPod(k8s, ns, fixtures.BuildPausedPod(), 10*time.Second)
+		if err != nil {
+			t.Errorf("error running pod %v: ", err)
+			return
+		}
 
-	_, err = k8s.CoreV1().Pods(ns).Create(
-		context.TODO(),
-		buildPausedPod(),
-		metav1.CreateOptions{},
-	)
-	if err != nil {
-		t.Errorf("failed to create pod: %v", err)
-		return
-	}
+		ephemeral := corev1.EphemeralContainer{
+			EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+				Name:    "ephemeral",
+				Image:   "busybox",
+				Command: []string{"sleep", "300"},
+				TTY:     true,
+				Stdin:   true,
+			},
+		}
 
-	timeout := time.Second * 15
-	running, err := k8s.NamespacedHelpers(ns).WaitPodRunning(
-		"paused",
-		timeout,
-	)
-	if err != nil {
-		t.Errorf("error waiting for pod: %v", err)
-		return
-	}
-	if !running {
-		t.Errorf("pod not ready after %f: ", timeout.Seconds())
-		return
-	}
+		err = k8s.NamespacedHelpers(ns).AttachEphemeralContainer("paused", ephemeral, 15*time.Second)
+		if err != nil {
+			t.Errorf("error attaching ephemeral container to pod: %v", err)
+			return
+		}
 
-	ephemeral := corev1.EphemeralContainer{
-		EphemeralContainerCommon: corev1.EphemeralContainerCommon{
-			Name:    "ephemeral",
-			Image:   "busybox",
-			Command: []string{"sleep", "300"},
-			TTY:     true,
-			Stdin:   true,
-		},
-	}
+		stdout, _, err := k8s.NamespacedHelpers(ns).Exec(
+			"paused",
+			"ephemeral",
+			[]string{"echo", "-n", "hello", "world"},
+			nil,
+		)
+		if err != nil {
+			t.Errorf("error executing command in pod: %v", err)
+			return
+		}
 
-	err = k8s.NamespacedHelpers(ns).AttachEphemeralContainer("paused", ephemeral, 15*time.Second)
-	if err != nil {
-		t.Errorf("error attaching ephemeral container to pod: %v", err)
-		return
-	}
-
-	stdout, _, err := k8s.NamespacedHelpers(ns).Exec(
-		"paused",
-		"ephemeral",
-		[]string{"echo", "-n", "hello", "world"},
-		nil,
-	)
-	if err != nil {
-		t.Errorf("error executing command in pod: %v", err)
-		return
-	}
-
-	greetings := "hello world"
-	if string(stdout) != "hello world" {
-		t.Errorf("stdout does not match expected result:\nexpected: %s\nactual%s\n", greetings, string(stdout))
-		return
-	}
+		greetings := "hello world"
+		if string(stdout) != "hello world" {
+			t.Errorf("stdout does not match expected result:\nexpected: %s\nactual%s\n", greetings, string(stdout))
+			return
+		}
+	})
 }

--- a/e2e/kubernetes/kubernetes_e2e_test.go
+++ b/e2e/kubernetes/kubernetes_e2e_test.go
@@ -49,7 +49,7 @@ func TestMain(m *testing.M) {
 	}
 
 	// retrieve path to kubeconfig
-	kubeconfig, _ = cluster.Kubeconfig()
+	kubeconfig = cluster.Kubeconfig()
 
 	// run tests
 	rc := m.Run()

--- a/pkg/testutils/cluster/cluster.go
+++ b/pkg/testutils/cluster/cluster.go
@@ -240,10 +240,6 @@ func (c *Cluster) Delete() error {
 }
 
 // Kubeconfig returns the path to the kubeconfig for the test cluster
-func (c *Cluster) Kubeconfig() (string, error) {
-	if c.kubeconfig == "" {
-		return "", nil
-	}
-
-	return c.kubeconfig, nil
+func (c *Cluster) Kubeconfig() string {
+	return c.kubeconfig
 }

--- a/pkg/testutils/e2e/checks/checks.go
+++ b/pkg/testutils/e2e/checks/checks.go
@@ -1,0 +1,51 @@
+// Package checks implements functions that verify conditions in a cluster
+package checks
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const (
+	DefaultSvcURL  = "http://127.0.0.1"
+	DefaultSvcPort = 32080
+)
+
+// ServiceCheck defines the conditions to check in the access to a service
+type ServiceCheck struct {
+	// Url to access the service (default http://127.0.0.1)
+	Url string
+	// Port to access the service (default 32080)
+	Port uint
+	// Expected return code (default 200)
+	ExpectedCode int
+	// Delay before attempting access to service
+	Delay time.Duration
+}
+
+// Checks access to service
+func CheckService(c ServiceCheck) error {
+	time.Sleep(c.Delay)
+
+	url := c.Url
+	if url == "" {
+		url = DefaultSvcURL
+	}
+	port := c.Port
+	if port == 0 {
+		port = DefaultSvcPort
+	}
+	requestUrl := fmt.Sprintf("%s:%d", url, port)
+	resp, err := http.Get(requestUrl)
+	if err != nil {
+		return fmt.Errorf("failed to access service at %s: %v", url, err)
+
+	}
+
+	if resp.StatusCode != c.ExpectedCode {
+		return fmt.Errorf("expected status code %d but %d received", c.ExpectedCode, resp.StatusCode)
+	}
+
+	return nil
+}

--- a/pkg/testutils/e2e/fixtures/fixtures.go
+++ b/pkg/testutils/e2e/fixtures/fixtures.go
@@ -1,0 +1,226 @@
+// Package fixtures implements fixtures for e2e tests
+package fixtures
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/grafana/xk6-disruptor/pkg/kubernetes"
+	"github.com/grafana/xk6-disruptor/pkg/testutils/cluster"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// BuildHttpbinPod returns the definition for deploying Httpbin as a Pod
+func BuildHttpbinPod() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "httpbin",
+			Labels: map[string]string{
+				"app": "httpbin",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:            "httpbin",
+					Image:           "kennethreitz/httpbin",
+					ImagePullPolicy: corev1.PullIfNotPresent,
+				},
+			},
+		},
+	}
+}
+
+// BuildHttpbinService returns a Service definition that exposes httpbin pods at the node port 32080
+func BuildHttpbinService() *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "httpbin",
+			Labels: map[string]string{
+				"app": "httpbin",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeNodePort,
+			Selector: map[string]string{
+				"app": "httpbin",
+			},
+			Ports: []corev1.ServicePort{
+				{
+					Name:     "http",
+					Port:     80,
+					NodePort: 32080,
+				},
+			},
+		},
+	}
+}
+
+// BuildBusyBoxPod returns the definition of a Pod that runs busybox and waits 5min before completing
+func BuildBusyBoxPod() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "busybox",
+			Labels: map[string]string{
+				"app": "busybox",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:            "busybox",
+					Image:           "busybox",
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Command:         []string{"sleep", "300"},
+				},
+			},
+		},
+	}
+}
+
+// BuildPausedPod returns the definition of a Pod that runs the paused image in a container
+// creating a "no-op" dummy Pod.
+func BuildPausedPod() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "paused",
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:            "paused",
+					Image:           "k8s.gcr.io/pause",
+					ImagePullPolicy: corev1.PullIfNotPresent,
+				},
+			},
+		},
+	}
+}
+
+// BuildNginxPod returns the definition of a Pod that runs Nginx
+func BuildNginxPod() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "nginx",
+			Labels: map[string]string{
+				"app": "nginx",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{
+					Name:            "nginx",
+					Image:           "nginx",
+					ImagePullPolicy: corev1.PullIfNotPresent,
+				},
+			},
+		},
+	}
+}
+
+// BuildNginxService returns the definition of a Service that exposes the nginx pod(s)
+func BuildNginxService() *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "nginx",
+			Labels: map[string]string{
+				"app": "nginx",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeNodePort,
+			Selector: map[string]string{
+				"app": "nginx",
+			},
+			Ports: []corev1.ServicePort{
+				{
+					Name:     "http",
+					Port:     80,
+					NodePort: 32080,
+				},
+			},
+		},
+	}
+}
+
+// Exposes a Service in the given namespace and waits for it to be ready
+func ExposeService(k8s kubernetes.Kubernetes, ns string, svc *corev1.Service, timeout time.Duration) error {
+	_, err := k8s.CoreV1().Services(ns).Create(
+		context.TODO(),
+		svc,
+		metav1.CreateOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf("failed to create service %s: %v", svc.Name, err)
+	}
+
+	// wait for the service to be ready for accepting requests
+	err = k8s.NamespacedHelpers(ns).WaitServiceReady(svc.Name, timeout)
+	if err != nil {
+		return fmt.Errorf("error waiting for service %s: %v", svc.Name, err)
+	}
+
+	return nil
+}
+
+// RunPod creates a pod and waits it for be running
+func RunPod(k8s kubernetes.Kubernetes, ns string, pod *corev1.Pod, timeout time.Duration) error {
+	_, err := k8s.CoreV1().Pods(ns).Create(
+		context.TODO(),
+		pod,
+		metav1.CreateOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf("error creating pod %s: %v", pod.Name, err)
+	}
+
+	running, err := k8s.NamespacedHelpers(ns).WaitPodRunning(
+		pod.Name,
+		timeout,
+	)
+	if err != nil {
+		return fmt.Errorf("error waiting for pod %s: %v", pod.Name, err)
+	}
+	if !running {
+		return fmt.Errorf("pod %s not ready after %f: ", pod.Name, timeout.Seconds())
+	}
+
+	return nil
+}
+
+// DeployApp deploys a pod in a namespace and exposes it as a service in a cluster
+func DeployApp(k8s kubernetes.Kubernetes, ns string, pod *corev1.Pod, svc *corev1.Service, timeout time.Duration) error {
+	start := time.Now()
+	err := RunPod(k8s, ns, pod, timeout)
+	if err != nil {
+		return fmt.Errorf("failed to create pod %s in namespace %s: %v", pod.Name, ns, err)
+	}
+
+	timeLeft := time.Duration(timeout - time.Since(start))
+	return ExposeService(k8s, ns, svc, timeLeft)
+}
+
+// BuildCluster builds a cluster exposing port 32080 and with the required images preloaded
+func BuildCluster(name string) (*cluster.Cluster, error) {
+	config, err := cluster.NewClusterConfig(
+		name,
+		cluster.ClusterOptions{
+			NodePorts: []cluster.NodePort{
+				{
+					NodePort: 32080,
+					HostPort: 32080,
+				},
+			},
+			Images: []string{"grafana/xk6-disruptor-agent"},
+			Wait:   time.Second * 60,
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cluster config: %w", err)
+	}
+
+	return config.Create()
+}


### PR DESCRIPTION
Refactor e2e tests to minimize redundancies in the setup of test environments.
Also, reorganize tests as sub-tests for sharing setup state (e.g. the test cluster) without requiring shared variables.