### PR TITLE
Prevent port collisions in e2e tests

### DIFF
--- a/pkg/testutils/e2e/checks/checks.go
+++ b/pkg/testutils/e2e/checks/checks.go
@@ -17,7 +17,7 @@ type ServiceCheck struct {
 	// Url to access the service (default http://127.0.0.1)
 	Url string
 	// Port to access the service (default 32080)
-	Port uint
+	Port int32
 	// Expected return code (default 200)
 	ExpectedCode int
 	// Delay before attempting access to service


### PR DESCRIPTION
Control allocation of node ports (mapped to host ports) between tests to prevent collisions (for example, one test accessing a service deployed by another test)

Signed-off-by: Pablo Chacin <pablochacin@gmail.com>