### PR TITLE
Add support to get kubeconfig's default path

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,11 @@ issues:
     - linters:
         - paralleltest # false positive: https://github.com/kunwardeep/paralleltest/issues/8.
       text: "does not use range value in test Run"
+    # As per https://github.com/golangci/golangci-lint/issues/207#issuecomment-534771981
+    - source: "^// http"
+      linters:
+        - lll
+      
 
 linters-settings:
   cyclop:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 work_dir = $(shell pwd)
-golangci_version = $(shell head -n 1 .golangci.yml | tr -d '# ')
+golangci_version = $(shell head -n 1 .golangci.yml | tr -d '\# ')
 
 all: build
 

--- a/disruptor.go
+++ b/disruptor.go
@@ -130,7 +130,8 @@ func (m *ModuleInstance) newServiceDisruptor(c goja.ConstructorCall) *goja.Objec
 	return rt.ToValue(disruptor).ToObject(rt)
 }
 
-// Copied from ahmetb/kubectx source code: https://github.com/ahmetb/kubectx/blob/29850e1a75cb5cad8d93f74a4114311eb9feba9f/internal/kubeconfig/kubeconfigloader.go#L59
+// Copied from ahmetb/kubectx source code:
+// https://github.com/ahmetb/kubectx/blob/29850e1a75cb5cad8d93f74a4114311eb9feba9f/internal/kubeconfig/kubeconfigloader.go#L59
 func getKubernetesConfigPath() (string, error) {
 	// KUBECONFIG env var
 	if v := os.Getenv("KUBECONFIG"); v != "" {


### PR DESCRIPTION
While trying the extension locally, it didn't work out of the box!

I got the following error:
```
➜  xk6-disruptor git:(main) ./k6 run examples/pod_disruptor.js

          /\      |‾‾| /‾‾/   /‾‾/   
     /\  /  \     |  |/  /   /  /    
    /  \/    \    |     (   /   ‾‾\  
   /          \   |  |\  \ |  (‾)  | 
  / __________ \  |__| \__\ \_____/ .io

W1114 11:02:40.879447   43950 client_config.go:617] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
W1114 11:02:40.879561   43950 client_config.go:622] error creating inClusterConfig, falling back to default config: unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined
ERRO[0000] GoError: error creating Kubernetes helper: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable
        at go.k6.io/k6/js.(*InitContext).Require-fm (native)
        at file:///Users/dgzlopes/go/src/github.com/grafana/xk6-disruptor/examples/pod_disruptor.js:1:0(14)
        at native  hint="script exception"
```

 I fixed this, by making the extension rely on the default path, in case the environment variable is not set.