### PR TITLE
Check k8s version

### DIFF
--- a/e2e/cluster/cluster_e2e_test.go
+++ b/e2e/cluster/cluster_e2e_test.go
@@ -178,3 +178,50 @@ func Test_PortAllocation(t *testing.T) {
 		return
 	}
 }
+
+func Test_KubernetesVersion(t *testing.T) {
+	// create cluster with default configuration
+	config, err := cluster.NewConfig(
+		"e2e-default-cluster",
+		cluster.Options{
+			Version: "v1.24.0",
+			Wait:    time.Second * 60,
+		},
+	)
+	if err != nil {
+		t.Errorf("failed creating cluster configuration: %v", err)
+		return
+	}
+
+	cluster, err := config.Create()
+	if err != nil {
+		t.Errorf("failed to create cluster: %v", err)
+		return
+	}
+
+	// delete cluster
+	cluster.Delete()
+}
+
+func Test_InvalidKubernetesVersion(t *testing.T) {
+	// create cluster with default configuration
+	config, err := cluster.NewConfig(
+		"e2e-default-cluster",
+		cluster.Options{
+			Version: "v0.0.0",
+			Wait:    time.Second * 60,
+		},
+	)
+	if err != nil {
+		t.Errorf("failed creating cluster configuration: %v", err)
+		return
+	}
+
+	cluster, err := config.Create()
+	if err == nil {
+		t.Errorf("Should have failed creating cluster")
+		cluster.Delete()
+		return
+	}
+
+}

--- a/e2e/kubernetes/kubernetes_e2e_test.go
+++ b/e2e/kubernetes/kubernetes_e2e_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/grafana/xk6-disruptor/pkg/kubernetes"
+	"github.com/grafana/xk6-disruptor/pkg/testutils/cluster"
 	"github.com/grafana/xk6-disruptor/pkg/testutils/e2e/checks"
 	"github.com/grafana/xk6-disruptor/pkg/testutils/e2e/fixtures"
 
@@ -187,4 +188,31 @@ func Test_Kubernetes(t *testing.T) {
 			return
 		}
 	})
+}
+
+func Test_UnsupportedKubernetesVersion(t *testing.T) {
+	config, err := cluster.NewConfig(
+		"e2e-v1-22-0-cluster",
+		cluster.Options{
+			Version: "v1.22.0",
+			Wait:    time.Second * 60,
+		},
+	)
+	if err != nil {
+		t.Errorf("failed creating cluster configuration: %v", err)
+		return
+	}
+
+	cluster, err := config.Create()
+	if err != nil {
+		t.Errorf("failed to create cluster: %v", err)
+		return
+	}
+	defer cluster.Delete()
+
+	_, err = kubernetes.NewFromKubeconfig(cluster.Kubeconfig())
+	if err == nil {
+		t.Errorf("should had failed creating kubernetes client")
+		return
+	}
 }


### PR DESCRIPTION
xk6-disruptor requires at least Kubernetes v1.23.0 to work. This change set checks for the version of Kubernetes the client is connected to and throws an error if this requirement is not satisfied.

The change set also introduces the option for Kubernetes version in the test clusters to allow testing against different Kubernetes versions.