### PR TITLE
Use API Server proxy for accessing services in e2e tests

### DIFF
--- a/e2e/disruptors/http/http_e2e_test.go
+++ b/e2e/disruptors/http/http_e2e_test.go
@@ -97,23 +97,22 @@ func Test_InjectHttp500(t *testing.T) {
 		return
 	}
 
-	nodePort := cluster.AllocatePort()
-	if nodePort.HostPort == 0 {
-		t.Errorf("no nodeport available for test")
-		return
-	}
-	defer cluster.ReleasePort(nodePort)
-
-	err = fixtures.ExposeService(k8s, ns, fixtures.BuildHttpbinService(nodePort.NodePort), 20*time.Second)
+	err = fixtures.ExposeService(k8s, ns, fixtures.BuildHttpbinService(), 20*time.Second)
 	if err != nil {
 		t.Errorf("failed to create service: %v", err)
 		return
 	}
 
-	err = checks.CheckService(checks.ServiceCheck{
-		Port:         nodePort.HostPort,
-		ExpectedCode: 500,
-	})
+	err = checks.CheckService(
+		k8s,
+		checks.ServiceCheck{
+			Namespace:    ns,
+			Service:      "httpbin",
+			Port:         80,
+			Path:         "/status/200",
+			ExpectedCode: 500,
+		},
+	)
 
 	if err != nil {
 		t.Errorf("failed : %v", err)

--- a/pkg/kubernetes/helpers/fake.go
+++ b/pkg/kubernetes/helpers/fake.go
@@ -2,6 +2,9 @@ package helpers
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"strings"
 	"sync"
 
 	"k8s.io/client-go/kubernetes"
@@ -86,4 +89,36 @@ func NewFakeHelper(client kubernetes.Interface, namespace string, executor *Fake
 // Fakes the execution of a command in a pod
 func (f *fakeHelper) Exec(pod string, container string, command []string, stdin []byte) ([]byte, []byte, error) {
 	return f.executor.Exec(pod, container, command, stdin)
+}
+
+// FakeHTTPClient implement a fake HTTPClient that returns a fixed response.
+// When invoked, it records the request it received
+type FakeHTTPClient struct {
+	Request  *http.Request
+	Response *http.Response
+	Err      error
+}
+
+// newFakeHTTPClient creates a FakeHTTPClient that returns a fixed response from a status and an content body
+func newFakeHTTPClient(status int, body []byte) *FakeHTTPClient {
+	response := &http.Response{
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		StatusCode:    status,
+		Status:        http.StatusText(status),
+		Body:          io.NopCloser(strings.NewReader(string(body))),
+		ContentLength: int64(len(body)),
+	}
+
+	return &FakeHTTPClient{
+		Response: response,
+		Err:      nil,
+	}
+}
+
+// Do implements HTTPClient's Do method
+func (f *FakeHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	f.Request = req
+	return f.Response, f.Err
 }

--- a/pkg/kubernetes/helpers/services.go
+++ b/pkg/kubernetes/helpers/services.go
@@ -2,17 +2,21 @@ package helpers
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/grafana/xk6-disruptor/pkg/utils"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
 )
 
 // ServiceHelper implements functions for dealing with services
 type ServiceHelper interface {
 	// WaitServiceReady waits for the given service to have at least one endpoint available
 	WaitServiceReady(service string, timeout time.Duration) error
+	// GetServiceProxy returns a client for making HTTP requests to the service using api server's proxy
+	GetServiceProxy(service string, port int) (ServiceClient, error)
 }
 
 func (h *helpers) WaitServiceReady(service string, timeout time.Duration) error {
@@ -33,4 +37,70 @@ func (h *helpers) WaitServiceReady(service string, timeout time.Duration) error 
 
 		return false, nil
 	})
+}
+
+// ServiceClient is the minimal interface for executing HTTP requests
+// Offers an interface similar to http.Client but only the Do method is supported
+// It is used primarily to allow mocking the client in unit tests
+type ServiceClient interface {
+	// Do executes the request to the service and returns the response
+	// From the request only the URL path method, headers and body are considered
+	Do(request *http.Request) (*http.Response, error)
+}
+
+// ServiceProxy implements the HTTPClient interface for making HTTP request to a service
+type ServiceProxy struct {
+	service   string
+	namespace string
+	port      int
+	baseURL   string
+	client    ServiceClient
+}
+
+// newServiceProxy creates a ServiceProxy
+func newServiceProxy(
+	httpClient ServiceClient,
+	host string,
+	namespace string,
+	service string,
+	port int,
+) *ServiceProxy {
+	// build url to the service proxy
+	baseURL := fmt.Sprintf("%s/api/v1/namespaces/%s/services/%s:%d/proxy", host, namespace, service, port)
+
+	return &ServiceProxy{
+		client:    httpClient,
+		service:   service,
+		namespace: namespace,
+		baseURL:   baseURL,
+		port:      port,
+	}
+}
+
+func (h *helpers) GetServiceProxy(service string, port int) (ServiceClient, error) {
+	httpClient, err := rest.HTTPClientFor(h.config)
+	if err != nil {
+		return nil, err
+	}
+
+	return newServiceProxy(
+		httpClient,
+		h.config.Host,
+		h.namespace,
+		service,
+		port,
+	), nil
+}
+
+// Do implements the Do method from the ServiceClient interface
+func (c *ServiceProxy) Do(request *http.Request) (*http.Response, error) {
+	serviceURL := c.baseURL + request.URL.Path
+	serviceRequest, err := http.NewRequest(request.Method, serviceURL, request.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	serviceRequest.Header = request.Header
+
+	return c.client.Do(serviceRequest)
 }

--- a/pkg/testutils/e2e/fixtures/fixtures.go
+++ b/pkg/testutils/e2e/fixtures/fixtures.go
@@ -35,7 +35,7 @@ func BuildHttpbinPod() *corev1.Pod {
 }
 
 // BuildHttpbinService returns a Service definition that exposes httpbin pods at the node port 32080
-func BuildHttpbinService(nodeport int32) *corev1.Service {
+func BuildHttpbinService() *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "httpbin",
@@ -50,9 +50,8 @@ func BuildHttpbinService(nodeport int32) *corev1.Service {
 			},
 			Ports: []corev1.ServicePort{
 				{
-					Name:     "http",
-					Port:     80,
-					NodePort: nodeport,
+					Name: "http",
+					Port: 80,
 				},
 			},
 		},
@@ -122,7 +121,7 @@ func BuildNginxPod() *corev1.Pod {
 }
 
 // BuildNginxService returns the definition of a Service that exposes the nginx pod(s)
-func BuildNginxService(nodeport int32) *corev1.Service {
+func BuildNginxService() *corev1.Service {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "nginx",
@@ -137,9 +136,8 @@ func BuildNginxService(nodeport int32) *corev1.Service {
 			},
 			Ports: []corev1.ServicePort{
 				{
-					Name:     "http",
-					Port:     80,
-					NodePort: nodeport,
+					Name: "http",
+					Port: 80,
 				},
 			},
 		},


### PR DESCRIPTION
Use API Server proxy instead of exposing services as NodePort and relay on host port mapping capability offered by kind.
This will reduce issues with port allocation (e.g. conflicts between tests) and also will make tests more portable across test clusters. 
