### PR TITLE
Support in-cluster config

### DIFF
--- a/e2e/agent/agent_e2e_test.go
+++ b/e2e/agent/agent_e2e_test.go
@@ -81,7 +81,7 @@ func Test_Agent(t *testing.T) {
 		_ = cluster.Delete()
 	})
 
-	k8s, err := kubernetes.NewFromKubeconfig(cluster.Kubeconfig())
+	k8s, err := kubernetes.NewFromKubeconfig(context.TODO(), cluster.Kubeconfig())
 	if err != nil {
 		t.Errorf("error creating kubernetes client: %v", err)
 		return

--- a/e2e/disruptors/pod_e2e_test.go
+++ b/e2e/disruptors/pod_e2e_test.go
@@ -25,7 +25,7 @@ func Test_PodDisruptor(t *testing.T) {
 		return
 	}
 
-	k8s, err := kubernetes.NewFromKubeconfig(cluster.Kubeconfig())
+	k8s, err := kubernetes.NewFromKubeconfig(context.TODO(), cluster.Kubeconfig())
 	if err != nil {
 		t.Errorf("error creating kubernetes client: %v", err)
 		return

--- a/e2e/disruptors/service_e2e_test.go
+++ b/e2e/disruptors/service_e2e_test.go
@@ -24,7 +24,7 @@ func Test_ServiceDisruptor(t *testing.T) {
 	}
 	defer cluster.Delete()
 
-	k8s, err := kubernetes.NewFromKubeconfig(cluster.Kubeconfig())
+	k8s, err := kubernetes.NewFromKubeconfig(context.TODO(), cluster.Kubeconfig())
 	if err != nil {
 		t.Errorf("error creating kubernetes client: %v", err)
 		return

--- a/e2e/kubernetes/kubernetes_e2e_test.go
+++ b/e2e/kubernetes/kubernetes_e2e_test.go
@@ -26,7 +26,7 @@ func Test_Kubernetes(t *testing.T) {
 	}
 	defer cluster.Delete()
 
-	k8s, err := kubernetes.NewFromKubeconfig(cluster.Kubeconfig())
+	k8s, err := kubernetes.NewFromKubeconfig(context.TODO(), cluster.Kubeconfig())
 	if err != nil {
 		t.Errorf("error creating kubernetes client: %v", err)
 		return
@@ -36,7 +36,7 @@ func Test_Kubernetes(t *testing.T) {
 
 	// Test Creating a random namespace
 	t.Run("Create Random Namespace", func(t *testing.T) {
-		k8s, err := kubernetes.NewFromKubeconfig(kubeconfig)
+		k8s, err := kubernetes.NewFromKubeconfig(context.TODO(), kubeconfig)
 		if err != nil {
 			t.Errorf("error creating kubernetes client: %v", err)
 			return
@@ -209,7 +209,7 @@ func Test_UnsupportedKubernetesVersion(t *testing.T) {
 	}
 	defer cluster.Delete()
 
-	_, err = kubernetes.NewFromKubeconfig(cluster.Kubeconfig())
+	_, err = kubernetes.NewFromKubeconfig(context.TODO(), cluster.Kubeconfig())
 	if err == nil {
 		t.Errorf("should had failed creating kubernetes client")
 		return

--- a/pkg/kubernetes/config.go
+++ b/pkg/kubernetes/config.go
@@ -1,0 +1,31 @@
+package kubernetes
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+// getConfigPath Copied from ahmetb/kubectx source code:
+// https://github.com/ahmetb/kubectx/blob/29850e1a75cb5cad8d93f74a4114311eb9feba9f/internal/kubeconfig/kubeconfigloader.go#L59
+func getConfigPath() (string, error) {
+	// KUBECONFIG env var
+	if v := os.Getenv("KUBECONFIG"); v != "" {
+		list := filepath.SplitList(v)
+		if len(list) > 1 {
+			// TODO KUBECONFIG=file1:file2 currently not supported
+			return "", errors.New("multiple files in KUBECONFIG are currently not supported")
+		}
+		return v, nil
+	}
+
+	// default path
+	home := os.Getenv("HOME")
+	if home == "" {
+		home = os.Getenv("USERPROFILE") // windows
+	}
+	if home == "" {
+		return "", errors.New("HOME or USERPROFILE environment variable not set")
+	}
+	return filepath.Join(home, ".kube", "config"), nil
+}

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -4,6 +4,7 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/grafana/xk6-disruptor/pkg/kubernetes/helpers"
@@ -23,14 +24,6 @@ type Kubernetes interface {
 	NamespacedHelpers(namespace string) helpers.Helpers
 }
 
-// Config defines the configuration for creating a Kubernetes instance
-type Config struct {
-	// Context for executing kubernetes operations
-	Context context.Context
-	// Path to Kubernetes access configuration
-	Kubeconfig string
-}
-
 // k8s Holds the reference to the helpers for interacting with kubernetes
 type k8s struct {
 	config *rest.Config
@@ -38,8 +31,8 @@ type k8s struct {
 	ctx context.Context
 }
 
-// newWithContext returns a Kubernetes instance configured with the provided kubeconfig.
-func newWithContext(ctx context.Context, config *rest.Config) (Kubernetes, error) {
+// newFromConfig returns a Kubernetes instance configured with the provided kubeconfig.
+func newFromConfig(ctx context.Context, config *rest.Config) (Kubernetes, error) {
 	// As per the discussion in [1] client side rate limiting is no longer required.
 	// Setting a large limit
 	// [1] https://github.com/kubernetes/kubernetes/issues/111880
@@ -64,21 +57,13 @@ func newWithContext(ctx context.Context, config *rest.Config) (Kubernetes, error
 }
 
 // NewFromKubeconfig returns a Kubernetes instance configured with the kubeconfig pointed by the given path
-func NewFromKubeconfig(kubeconfig string) (Kubernetes, error) {
-	return NewFromConfig(Config{
-		Kubeconfig: kubeconfig,
-		Context:    context.TODO(),
-	})
-}
-
-// NewFromConfig returns a Kubernetes instance configured with the given options
-func NewFromConfig(c Config) (Kubernetes, error) {
-	config, err := clientcmd.BuildConfigFromFlags("", c.Kubeconfig)
+func NewFromKubeconfig(ctx context.Context, kubeconfig string) (Kubernetes, error) {
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
 		return nil, err
 	}
 
-	return newWithContext(c.Context, config)
+	return newFromConfig(ctx, config)
 }
 
 // New returns a Kubernetes instance or an error when no config is eligible to be used.
@@ -88,17 +73,20 @@ func NewFromConfig(c Config) (Kubernetes, error) {
 // 3. $HOME/.kube/config file.
 func New(ctx context.Context) (Kubernetes, error) {
 	k8sConfig, err := rest.InClusterConfig()
-	if err != nil {
-		kubeConfigPath, getConfigErr := getConfigPath()
-		if getConfigErr != nil {
-			return nil, fmt.Errorf("error getting kubernetes config path: %w", getConfigErr)
-		}
-		return NewFromConfig(Config{
-			Context:    ctx,
-			Kubeconfig: kubeConfigPath,
-		})
+	if err == nil {
+		return newFromConfig(ctx, k8sConfig)
 	}
-	return newWithContext(ctx, k8sConfig)
+
+	if !errors.Is(err, rest.ErrNotInCluster) {
+		return nil, err
+	}
+
+	kubeConfigPath, getConfigErr := getConfigPath()
+	if getConfigErr != nil {
+		return nil, fmt.Errorf("error getting kubernetes config path: %w", getConfigErr)
+	}
+
+	return NewFromKubeconfig(ctx, kubeConfigPath)
 }
 
 func checkK8sVersion(config *rest.Config) error {

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -38,20 +38,8 @@ type k8s struct {
 	ctx context.Context
 }
 
-// NewFromKubeconfig returns a Kubernetes instance configured with the kubeconfig pointed by the given path
-func NewFromKubeconfig(kubeconfig string) (Kubernetes, error) {
-	return NewFromConfig(Config{
-		Kubeconfig: kubeconfig,
-	})
-}
-
-// NewFromConfig returns a Kubernetes instance configured with the given options
-func NewFromConfig(c Config) (Kubernetes, error) {
-	config, err := clientcmd.BuildConfigFromFlags("", c.Kubeconfig)
-	if err != nil {
-		return nil, err
-	}
-
+// New returns a Kubernetes instance configured with the provided kubeconfig.
+func New(ctx context.Context, config *rest.Config) (Kubernetes, error) {
 	// As per the discussion in [1] client side rate limiting is no longer required.
 	// Setting a large limit
 	// [1] https://github.com/kubernetes/kubernetes/issues/111880
@@ -68,7 +56,6 @@ func NewFromConfig(c Config) (Kubernetes, error) {
 		return nil, err
 	}
 
-	ctx := c.Context
 	if ctx == nil {
 		ctx = context.TODO()
 	}
@@ -78,6 +65,23 @@ func NewFromConfig(c Config) (Kubernetes, error) {
 		Interface: client,
 		ctx:       ctx,
 	}, nil
+}
+
+// NewFromKubeconfig returns a Kubernetes instance configured with the kubeconfig pointed by the given path
+func NewFromKubeconfig(kubeconfig string) (Kubernetes, error) {
+	return NewFromConfig(Config{
+		Kubeconfig: kubeconfig,
+	})
+}
+
+// NewFromConfig returns a Kubernetes instance configured with the given options
+func NewFromConfig(c Config) (Kubernetes, error) {
+	config, err := clientcmd.BuildConfigFromFlags("", c.Kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return New(c.Context, config)
 }
 
 func checkK8sVersion(config *rest.Config) error {

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -56,10 +56,6 @@ func newWithContext(ctx context.Context, config *rest.Config) (Kubernetes, error
 		return nil, err
 	}
 
-	if ctx == nil {
-		ctx = context.TODO()
-	}
-
 	return &k8s{
 		config:    config,
 		Interface: client,
@@ -71,6 +67,7 @@ func newWithContext(ctx context.Context, config *rest.Config) (Kubernetes, error
 func NewFromKubeconfig(kubeconfig string) (Kubernetes, error) {
 	return NewFromConfig(Config{
 		Kubeconfig: kubeconfig,
+		Context:    context.TODO(),
 	})
 }
 


### PR DESCRIPTION
Signed-off-by: Marcos Candeia <marrcooos@gmail.com>

# Description
Implemented support for incluster config when running the pod within the target kubernetes cluster.

The in-cluster config is used by default and only then falling back to the kubeconfig file approach.

Fixes #96 

# Checklist:

- [x] My code follows the coding style of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
