### PR TITLE
Do not expose nodeports in e2e tests

### DIFF
--- a/pkg/testutils/e2e/fixtures/fixtures.go
+++ b/pkg/testutils/e2e/fixtures/fixtures.go
@@ -210,18 +210,11 @@ func DeployApp(
 
 // BuildCluster builds a cluster exposing port 32080 and with the required images preloaded
 func BuildCluster(name string) (*cluster.Cluster, error) {
-	// map node ports in the range 32080-32089 to host ports
-	nodePorts := []cluster.NodePort{}
-	for port := 32080; port < 32090; port++ {
-		nodePorts = append(nodePorts, cluster.NodePort{HostPort: int32(port), NodePort: int32(port)})
-	}
-
 	config, err := cluster.NewConfig(
 		name,
 		cluster.Options{
-			NodePorts: nodePorts,
-			Images:    []string{"ghcr.io/grafana/xk6-disruptor-agent:latest"},
-			Wait:      time.Second * 60,
+			Images: []string{"ghcr.io/grafana/xk6-disruptor-agent:latest"},
+			Wait:   time.Second * 60,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
# Description

Do not expose nodeports in the setup of e2e clusters.

Fixes #108 

# Checklist:

- [X] My code follows the coding style of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
