### PR TITLE
Use Enpoints to find ServiceDisruptor's targets

### DIFF
--- a/e2e/agent/agent_e2e_test.go
+++ b/e2e/agent/agent_e2e_test.go
@@ -69,6 +69,7 @@ func buildHttpbinPodWithDisruptorAgent(args []string) *corev1.Pod {
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Ports: []corev1.ContainerPort{
 						{
+							Name: "http",
 							ContainerPort: 80,
 						},
 					},

--- a/e2e/disruptors/service_e2e_test.go
+++ b/e2e/disruptors/service_e2e_test.go
@@ -67,6 +67,7 @@ func Test_ServiceDisruptor(t *testing.T) {
 		// apply disruption in a go-routine as it is a blocking function
 		go func() {
 			fault := disruptors.HTTPFault{
+				Port: 80,
 				ErrorRate: 1.0,
 				ErrorCode: 500,
 			}

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -391,6 +391,7 @@ func Test_ServiceDisruptorConstructor(t *testing.T) {
 		{
 			description: "valid constructor",
 			script: `
+			// do not wait for fault injection
 			const opts = {
 				injectTimeout: 0
 			}
@@ -463,9 +464,15 @@ func Test_ServiceDisruptorConstructor(t *testing.T) {
 				return
 			}
 
-			// create a service because the ServiceDisruptor's constructor expects it to exist
-			svc := builders.NewServiceBuilder("service").Build()
+			// create a k8s resources because the ServiceDisruptor's constructor expects it to exist
+			labels := map[string]string{
+				"app": "test",
+			}
+			svc := builders.NewServiceBuilder("service").WithSelector(labels).Build()
+			ep := builders.NewEndPointsBuilder("service").Build()
+
 			_, _ = env.k8s.CoreV1().Services("default").Create(context.TODO(), svc, v1.CreateOptions{})
+			_, _ = env.k8s.CoreV1().Endpoints("default").Create(context.TODO(), ep, v1.CreateOptions{})
 
 			_, err = env.rt.RunString(tc.script)
 

--- a/pkg/disruptors/cmd_builders.go
+++ b/pkg/disruptors/cmd_builders.go
@@ -1,0 +1,91 @@
+package disruptors
+
+import "fmt"
+
+//nolint:dupl
+func buildGrpcFaultCmd(fault GrpcFault, duration uint, options GrpcDisruptionOptions) []string {
+	cmd := []string{
+		"xk6-disruptor-agent",
+		"grpc",
+		"-d", fmt.Sprintf("%ds", duration),
+	}
+
+	if fault.AverageDelay > 0 {
+		cmd = append(cmd, "-a", fmt.Sprint(fault.AverageDelay), "-v", fmt.Sprint(fault.DelayVariation))
+	}
+
+	if fault.ErrorRate > 0 {
+		cmd = append(
+			cmd,
+			"-s",
+			fmt.Sprint(fault.StatusCode),
+			"-r",
+			fmt.Sprint(fault.ErrorRate),
+		)
+		if fault.StatusMessage != "" {
+			cmd = append(cmd, "-m", fault.StatusMessage)
+		}
+	}
+
+	if fault.Port != 0 {
+		cmd = append(cmd, "-t", fmt.Sprint(fault.Port))
+	}
+
+	if len(fault.Exclude) > 0 {
+		cmd = append(cmd, "-x", fault.Exclude)
+	}
+
+	if options.ProxyPort != 0 {
+		cmd = append(cmd, "-p", fmt.Sprint(options.ProxyPort))
+	}
+
+	if options.Iface != "" {
+		cmd = append(cmd, "-i", options.Iface)
+	}
+
+	return cmd
+}
+
+//nolint:dupl
+func buildHTTPFaultCmd(fault HTTPFault, duration uint, options HTTPDisruptionOptions) []string {
+	cmd := []string{
+		"xk6-disruptor-agent",
+		"http",
+		"-d", fmt.Sprintf("%ds", duration),
+	}
+
+	if fault.AverageDelay > 0 {
+		cmd = append(cmd, "-a", fmt.Sprint(fault.AverageDelay), "-v", fmt.Sprint(fault.DelayVariation))
+	}
+
+	if fault.ErrorRate > 0 {
+		cmd = append(
+			cmd,
+			"-e",
+			fmt.Sprint(fault.ErrorCode),
+			"-r",
+			fmt.Sprint(fault.ErrorRate),
+		)
+		if fault.ErrorBody != "" {
+			cmd = append(cmd, "-b", fault.ErrorBody)
+		}
+	}
+
+	if fault.Port != 0 {
+		cmd = append(cmd, "-t", fmt.Sprint(fault.Port))
+	}
+
+	if len(fault.Exclude) > 0 {
+		cmd = append(cmd, "-x", fault.Exclude)
+	}
+
+	if options.ProxyPort != 0 {
+		cmd = append(cmd, "-p", fmt.Sprint(options.ProxyPort))
+	}
+
+	if options.Iface != "" {
+		cmd = append(cmd, "-i", options.Iface)
+	}
+
+	return cmd
+}

--- a/pkg/disruptors/contoller.go
+++ b/pkg/disruptors/contoller.go
@@ -150,6 +150,12 @@ func NewAgentController(
 	targets []string,
 	timeout time.Duration,
 ) AgentController {
+	if timeout == 0 {
+		timeout = 30 * time.Second
+	}
+	if timeout < 0 {
+		timeout = 0
+	}
 	return &agentController{
 		ctx:       ctx,
 		k8s:       k8s,

--- a/pkg/disruptors/contoller.go
+++ b/pkg/disruptors/contoller.go
@@ -18,9 +18,11 @@ type AgentController interface {
 	// InjectDisruptorAgent injects the Disruptor agent in the target pods
 	InjectDisruptorAgent() error
 	// ExecCommand executes a command in the targets of the AgentController and reports any error
-	ExecCommand(cmd ...string) error
+	ExecCommand(cmd []string) error
 	// Targets returns the list of targets for the controller
 	Targets() ([]string, error)
+	// Visit allows executing a different command on each target returned by a visiting function
+	Visit(func(target string) []string) error
 }
 
 // AgentController controls de agents in a set of target pods
@@ -97,11 +99,21 @@ func (c *agentController) InjectDisruptorAgent() error {
 }
 
 // ExecCommand executes a command in the targets of the AgentController and reports any error
-func (c *agentController) ExecCommand(cmd ...string) error {
+func (c *agentController) ExecCommand(cmd []string) error {
+	// visit each target with the same command
+	return c.Visit(func(string) []string {
+		return cmd
+	})
+}
+
+// Visit allows executing a different command on each target returned by a visiting function
+func (c *agentController) Visit(visitor func(string) []string) error {
 	var wg sync.WaitGroup
 	// ensure errors channel has enough space to avoid blocking gorutines
 	errors := make(chan error, len(c.targets))
 	for _, pod := range c.targets {
+		// get the command to execute in the target
+		cmd := visitor(pod)
 		wg.Add(1)
 		// attach each container asynchronously
 		go func(pod string) {

--- a/pkg/disruptors/controller_test.go
+++ b/pkg/disruptors/controller_test.go
@@ -133,7 +133,7 @@ func Test_ExecCommand(t *testing.T) {
 			executor.SetResult(tc.stdout, tc.stderr, tc.err)
 			controller := NewAgentController(context.TODO(), k8s, testNamespace, tc.targets, tc.timeout)
 
-			err := controller.ExecCommand()
+			err := controller.ExecCommand(tc.command)
 			if tc.expectError && err == nil {
 				t.Errorf("should had failed")
 				return

--- a/pkg/disruptors/controller_test.go
+++ b/pkg/disruptors/controller_test.go
@@ -21,7 +21,7 @@ func Test_InjectAgent(t *testing.T) {
 	testCases := []struct {
 		title   string
 		targets []string
-		// Set timeout to 0 to prevent waiting the ephemeral container to be ready,
+		// Set timeout to -1 to prevent waiting the ephemeral container to be ready,
 		// as the fake client will not update its status
 		timeout     time.Duration
 		expectError bool
@@ -29,7 +29,7 @@ func Test_InjectAgent(t *testing.T) {
 		{
 			title:       "Inject ephemeral container",
 			targets:     []string{"pod1", "pod2"},
-			timeout:     0,
+			timeout:     -1,
 			expectError: false,
 		},
 		{

--- a/pkg/disruptors/pod.go
+++ b/pkg/disruptors/pod.go
@@ -156,7 +156,7 @@ func buildHTTPFaultCmd(fault HTTPFault, duration uint, options HTTPDisruptionOpt
 func (d *podDisruptor) InjectHTTPFaults(fault HTTPFault, duration uint, options HTTPDisruptionOptions) error {
 	cmd := buildHTTPFaultCmd(fault, duration, options)
 
-	err := d.controller.ExecCommand(cmd...)
+	err := d.controller.ExecCommand(cmd)
 	return err
 }
 
@@ -207,6 +207,6 @@ func buildGrpcFaultCmd(fault GrpcFault, duration uint, options GrpcDisruptionOpt
 // InjectGrpcFaults injects faults in the grpc requests sent to the disruptor's targets
 func (d *podDisruptor) InjectGrpcFaults(fault GrpcFault, duration uint, options GrpcDisruptionOptions) error {
 	cmd := buildGrpcFaultCmd(fault, duration, options)
-	err := d.controller.ExecCommand(cmd...)
+	err := d.controller.ExecCommand(cmd)
 	return err
 }

--- a/pkg/disruptors/pod_test.go
+++ b/pkg/disruptors/pod_test.go
@@ -23,9 +23,20 @@ func (f *fakeAgentController) InjectDisruptorAgent() error {
 	return nil
 }
 
-func (f *fakeAgentController) ExecCommand(cmd ...string) error {
+func (f *fakeAgentController) ExecCommand(cmd []string) error {
 	_, err := f.executor.Exec(cmd[0], cmd[1:]...)
 	return err
+}
+
+func (f *fakeAgentController) Visit(visitor func(string) []string) error {
+	for _, t := range f.targets {
+		cmd := visitor(t)
+		_, err := f.executor.Exec(cmd[0], cmd[1:]...)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func newPodDisruptorForTesting(ctx context.Context, selector PodSelector, controller AgentController) PodDisruptor {

--- a/pkg/disruptors/test_helpers.go
+++ b/pkg/disruptors/test_helpers.go
@@ -2,11 +2,28 @@ package disruptors
 
 import (
 	"sort"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 const (
 	testNamespace = "test-ns"
 )
+
+// simplified description of a Service used for building a corev1.Service Object
+type serviceDesc struct {
+	name      string
+	namespace string
+	ports     []corev1.ServicePort
+	selector  map[string]string
+}
+
+// simplified definition of EndPoint used to build a corev1.Endpoint object
+// lists the names of pods that expose the given EndpointPort
+type endpoint struct {
+	ports []corev1.EndpointPort
+	pods  []string
+}
 
 // podDesc describes a pod for a test
 type podDesc struct {

--- a/pkg/testutils/e2e/fixtures/fixtures.go
+++ b/pkg/testutils/e2e/fixtures/fixtures.go
@@ -11,6 +11,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 // BuildHttpbinPod returns the definition for deploying Httpbin as a Pod
@@ -28,6 +29,12 @@ func BuildHttpbinPod() *corev1.Pod {
 					Name:            "httpbin",
 					Image:           "kennethreitz/httpbin",
 					ImagePullPolicy: corev1.PullIfNotPresent,
+					Ports: []corev1.ContainerPort{
+						{
+							Name:          "http",
+							ContainerPort: 80,
+						},
+					},
 				},
 			},
 		},
@@ -76,8 +83,9 @@ func BuildHttpbinService() *corev1.Service {
 			},
 			Ports: []corev1.ServicePort{
 				{
-					Name: "http",
-					Port: 80,
+					Name:       "http",
+					Port:       80,
+					TargetPort: intstr.FromString("http"),
 				},
 			},
 		},


### PR DESCRIPTION
# Description

Use the Endpoints to find the targets for a ServiceDisruptor, considering port mappings

Fixes #130 

# Checklist:

- [x] My code follows the coding style of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have made corresponding changes to the documentation~~
- [x] I have added tests that prove my fix is effective or that my feature works.   
- [ ] ~~Any dependent changes have been merged and published in downstream modules~~
      
 
