### PR TITLE
Set agent's container sercurity context

### DIFF
--- a/pkg/disruptors/controller.go
+++ b/pkg/disruptors/controller.go
@@ -37,6 +37,12 @@ type agentController struct {
 // InjectDisruptorAgent injects the Disruptor agent in the target pods
 // TODO: use the agent version that matches the extension version
 func (c *agentController) InjectDisruptorAgent() error {
+	var (
+		rootUser     = int64(0)
+		rootGroup    = int64(0)
+		runAsNonRoot = false
+	)
+
 	agentContainer := corev1.EphemeralContainer{
 		EphemeralContainerCommon: corev1.EphemeralContainerCommon{
 			Name:            "xk6-agent",
@@ -46,6 +52,9 @@ func (c *agentController) InjectDisruptorAgent() error {
 				Capabilities: &corev1.Capabilities{
 					Add: []corev1.Capability{"NET_ADMIN"},
 				},
+				RunAsUser:    &rootUser,
+				RunAsGroup:   &rootGroup,
+				RunAsNonRoot: &runAsNonRoot,
 			},
 			TTY:   true,
 			Stdin: true,


### PR DESCRIPTION
# Description

Set security context to override restrictions in the PodSecurityContext that force the agent to run as a non root user

Fixes https://github.com/grafana/xk6-disruptor/issues/134

# Checklist:

- [x ] My code follows the coding style of this project
- [x ] I have performed a self-review of my code
- [x ] I have commented on my code, particularly in hard-to-understand areas
- [x ] I have made corresponding changes to the documentation
- [x ] I have added tests that prove my fix is effective or that my feature works. (tested following instructions in issue #134 describing how to reproduce the error )
- [x ] Any dependent changes have been merged and published in downstream modules<br>
      
 
