### PR TITLE
Reuse cluster across agent e2e tests

### DIFF
--- a/e2e/agent/agent_e2e_test.go
+++ b/e2e/agent/agent_e2e_test.go
@@ -133,122 +133,7 @@ func buildGrpcbinPodWithDisruptorAgent(args []string) *corev1.Pod {
 	}
 }
 
-func Test_HTTP(t *testing.T) {
-	t.Parallel()
-
-	cluster, err := fixtures.BuildCluster("e2e-xk6-agent")
-	if err != nil {
-		t.Errorf("failed to create cluster config: %v", err)
-		return
-	}
-
-	t.Cleanup(func() {
-		_ = cluster.Delete()
-	})
-
-	k8s, err := kubernetes.NewFromKubeconfig(cluster.Kubeconfig())
-	if err != nil {
-		t.Errorf("error creating kubernetes client: %v", err)
-		return
-	}
-
-	testCases := []struct {
-		// description of the test
-		title string
-		// command to pass to disruptor agent running in the target pod
-		cmd []string
-		// Function that checks the test conditions
-		check func(k8s kubernetes.Kubernetes, ns string) error
-	}{
-		{
-			title: "Inject HTTP 500",
-			cmd:   injectHTTP500,
-			check: func(k8s kubernetes.Kubernetes, ns string) error {
-				err = fixtures.ExposeService(k8s, ns, fixtures.BuildHttpbinService(), 20*time.Second)
-				if err != nil {
-					return fmt.Errorf("failed to create service: %v", err)
-				}
-				return checks.CheckService(
-					k8s,
-					checks.ServiceCheck{
-						Namespace:    ns,
-						Service:      "httpbin",
-						Port:         80,
-						Path:         "/status/200",
-						ExpectedCode: 500,
-					},
-				)
-			},
-		},
-		{
-			title: "Prevent execution of multiple commands",
-			cmd:   injectHTTP500,
-			check: func(k8s kubernetes.Kubernetes, ns string) error {
-				_, stderr, err := k8s.NamespacedHelpers(ns).Exec(
-					"httpbin",
-					"xk6-disruptor-agent",
-					[]string{
-						"xk6-disruptor-agent",
-						"http",
-						"--duration",
-						"300s",
-						"--rate",
-						"1.0",
-						"--error",
-						"500",
-						"--port",
-						"8080",
-						"--target",
-						"80",
-					},
-					[]byte{},
-				)
-				if err == nil {
-					return fmt.Errorf("command should had failed")
-				}
-
-				if !strings.Contains(string(stderr), "command is already in execution") {
-					return fmt.Errorf("unexpected error: %s: ", string(stderr))
-				}
-				return nil
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		tc := tc
-		t.Run(tc.title, func(t *testing.T) {
-			t.Parallel()
-			ns, err := k8s.Helpers().CreateRandomNamespace(context.TODO(), "test-")
-			if err != nil {
-				t.Errorf("error creating test namespace: %v", err)
-				return
-			}
-			defer k8s.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
-
-			err = fixtures.RunPod(
-				k8s,
-				ns,
-				buildHttpbinPodWithDisruptorAgent(tc.cmd),
-				30*time.Second,
-			)
-			if err != nil {
-				t.Errorf("failed to create pod: %v", err)
-				return
-			}
-
-			err = tc.check(k8s, ns)
-			if err != nil {
-				t.Errorf("failed : %v", err)
-				return
-			}
-		})
-	}
-}
-
-func Test_GRPC(t *testing.T) {
-	t.Parallel()
-
+func Test_Agent(t *testing.T) {
 	// we need to access the grpc service using a nodeport because
 	// we cannot use a service proxy as with http services
 	grpcPort := cluster.NodePort{
@@ -271,68 +156,169 @@ func Test_GRPC(t *testing.T) {
 		return
 	}
 
-	testCases := []struct {
-		// description of the test
-		title string
-		// command to pass to disruptor agent running in the target pod
-		cmd []string
-		// Function that checks the test conditions
-		check func(k8s kubernetes.Kubernetes, ns string) error
-	}{
-		{
-			title: "Inject Grpc Internal error",
-			cmd:   injectGrpcInternal,
-			check: func(k8s kubernetes.Kubernetes, ns string) error {
-				err = fixtures.ExposeService(k8s,
+	t.Run("Test HTTP Fault Injection", func (t *testing.T) {
+		t.Parallel()
+
+		testCases := []struct {
+			// description of the test
+			title string
+			// command to pass to disruptor agent running in the target pod
+			cmd []string
+			// Function that checks the test conditions
+			check func(k8s kubernetes.Kubernetes, ns string) error
+		}{
+			{
+				title: "Inject HTTP 500",
+				cmd:   injectHTTP500,
+				check: func(k8s kubernetes.Kubernetes, ns string) error {
+					err = fixtures.ExposeService(k8s, ns, fixtures.BuildHttpbinService(), 20*time.Second)
+					if err != nil {
+						return fmt.Errorf("failed to create service: %v", err)
+					}
+					return checks.CheckService(
+						k8s,
+						checks.ServiceCheck{
+							Namespace:    ns,
+							Service:      "httpbin",
+							Port:         80,
+							Path:         "/status/200",
+							ExpectedCode: 500,
+						},
+					)
+				},
+			},
+			{
+				title: "Prevent execution of multiple commands",
+				cmd:   injectHTTP500,
+				check: func(k8s kubernetes.Kubernetes, ns string) error {
+					_, stderr, err := k8s.NamespacedHelpers(ns).Exec(
+						"httpbin",
+						"xk6-disruptor-agent",
+						[]string{
+							"xk6-disruptor-agent",
+							"http",
+							"--duration",
+							"300s",
+							"--rate",
+							"1.0",
+							"--error",
+							"500",
+							"--port",
+							"8080",
+							"--target",
+							"80",
+						},
+						[]byte{},
+					)
+					if err == nil {
+						return fmt.Errorf("command should had failed")
+					}
+
+					if !strings.Contains(string(stderr), "command is already in execution") {
+						return fmt.Errorf("unexpected error: %s: ", string(stderr))
+					}
+					return nil
+				},
+			},
+		}
+
+		for _, tc := range testCases {
+			tc := tc
+			t.Run(tc.title, func(t *testing.T) {
+				t.Parallel()
+				ns, err := k8s.Helpers().CreateRandomNamespace(context.TODO(), "test-")
+				if err != nil {
+					t.Errorf("error creating test namespace: %v", err)
+					return
+				}
+				defer k8s.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+
+				err = fixtures.RunPod(
+					k8s,
 					ns,
-					fixtures.BuildGrpcbinService(uint(grpcPort.NodePort)),
-					20*time.Second,
+					buildHttpbinPodWithDisruptorAgent(tc.cmd),
+					30*time.Second,
 				)
 				if err != nil {
-					return fmt.Errorf("failed to create service: %v", err)
+					t.Errorf("failed to create pod: %v", err)
+					return
 				}
-				return checks.CheckGrpcService(
-					k8s,
-					checks.GrpcServiceCheck{
-						Host:           "localhost",
-						Port:           int(grpcPort.HostPort),
-						Service:        "grpcbin.GRPCBin",
-						Method:         "Empty",
-						Request:        []byte("{}"),
-						ExpectedStatus: 14, // grpc status Internal
-					},
-				)
+
+				err = tc.check(k8s, ns)
+				if err != nil {
+					t.Errorf("failed : %v", err)
+					return
+				}
+			})
+		}
+	})
+
+	t.Run("Test GRPC fault injection", func(t *testing.T) {
+		t.Parallel()
+
+		testCases := []struct {
+			// description of the test
+			title string
+			// command to pass to disruptor agent running in the target pod
+			cmd []string
+			// Function that checks the test conditions
+			check func(k8s kubernetes.Kubernetes, ns string) error
+		}{
+			{
+				title: "Inject Grpc Internal error",
+				cmd:   injectGrpcInternal,
+				check: func(k8s kubernetes.Kubernetes, ns string) error {
+					err = fixtures.ExposeService(k8s,
+						ns,
+						fixtures.BuildGrpcbinService(uint(grpcPort.NodePort)),
+						20*time.Second,
+					)
+					if err != nil {
+						return fmt.Errorf("failed to create service: %v", err)
+					}
+					return checks.CheckGrpcService(
+						k8s,
+						checks.GrpcServiceCheck{
+							Host:           "localhost",
+							Port:           int(grpcPort.HostPort),
+							Service:        "grpcbin.GRPCBin",
+							Method:         "Empty",
+							Request:        []byte("{}"),
+							ExpectedStatus: 14, // grpc status Internal
+						},
+					)
+				},
 			},
-		},
-	}
+		}
 
-	for _, tc := range testCases {
-		tc := tc
-		t.Run(tc.title, func(t *testing.T) {
-			t.Parallel()
-			ns, err := k8s.Helpers().CreateRandomNamespace(context.TODO(), "test-")
-			if err != nil {
-				t.Errorf("error creating test namespace: %v", err)
-				return
-			}
-			defer k8s.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
+		for _, tc := range testCases {
+			tc := tc
+			t.Run(tc.title, func(t *testing.T) {
+				t.Parallel()
+				ns, err := k8s.Helpers().CreateRandomNamespace(context.TODO(), "test-")
+				if err != nil {
+					t.Errorf("error creating test namespace: %v", err)
+					return
+				}
+				defer k8s.CoreV1().Namespaces().Delete(context.TODO(), ns, metav1.DeleteOptions{})
 
-			err = fixtures.RunPod(
-				k8s,
-				ns,
-				buildGrpcbinPodWithDisruptorAgent(tc.cmd),
-				30*time.Second,
-			)
-			if err != nil {
-				t.Errorf("failed to create pod: %v", err)
-				return
-			}
+				err = fixtures.RunPod(
+					k8s,
+					ns,
+					buildGrpcbinPodWithDisruptorAgent(tc.cmd),
+					30*time.Second,
+				)
+				if err != nil {
+					t.Errorf("failed to create pod: %v", err)
+					return
+				}
 
-			err = tc.check(k8s, ns)
-			if err != nil {
-				t.Errorf("failed : %v", err)
-				return
-			}
-		})
-	}
+				err = tc.check(k8s, ns)
+				if err != nil {
+					t.Errorf("failed : %v", err)
+					return
+				}
+			})
+		}
+	})
 }


### PR DESCRIPTION
# Description

Refactor agent e2e tests to reuse cluster. This prevents conflict between tests (they were sharing the same cluster name) and also speeds up the e2e tests.

# Checklist:

- [x] My code follows the coding style of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [ ] Any dependent changes have been merged and published in downstream modules
      
