### PR TITLE
Do not store context in structs

### DIFF
--- a/e2e/disruptors/pod_e2e_test.go
+++ b/e2e/disruptors/pod_e2e_test.go
@@ -111,7 +111,7 @@ func Test_PodDisruptor(t *testing.T) {
 					return
 				}
 
-				targets, _ := disruptor.Targets()
+				targets, _ := disruptor.Targets(context.TODO())
 				if len(targets) == 0 {
 					t.Errorf("No pods matched the selector")
 					return
@@ -119,7 +119,7 @@ func Test_PodDisruptor(t *testing.T) {
 
 				// apply disruption in a go-routine as it is a blocking function
 				go func() {
-					err := disruptor.InjectHTTPFaults(tc.fault, 60 * time.Second, tc.options)
+					err := disruptor.InjectHTTPFaults(context.TODO(), tc.fault, 60 * time.Second, tc.options)
 					if err != nil {
 						t.Logf("failed to setup disruptor: %v", err)
 						return
@@ -221,7 +221,7 @@ func Test_PodDisruptor(t *testing.T) {
 					return
 				}
 
-				targets, _ := disruptor.Targets()
+				targets, _ := disruptor.Targets(context.TODO())
 				if len(targets) == 0 {
 					t.Errorf("No pods matched the selector")
 					return
@@ -229,7 +229,7 @@ func Test_PodDisruptor(t *testing.T) {
 
 				// apply disruption in a go-routine as it is a blocking function
 				go func() {
-					err := disruptor.InjectGrpcFaults(tc.fault, 60 * time.Second, tc.options)
+					err := disruptor.InjectGrpcFaults(context.TODO(), tc.fault, 60 * time.Second, tc.options)
 					if err != nil {
 						t.Logf("failed to setup disruptor: %v", err)
 						return

--- a/e2e/disruptors/service_e2e_test.go
+++ b/e2e/disruptors/service_e2e_test.go
@@ -58,7 +58,7 @@ func Test_ServiceDisruptor(t *testing.T) {
 			return
 		}
 
-		targets, _ := disruptor.Targets()
+		targets, _ := disruptor.Targets(context.TODO())
 		if len(targets) == 0 {
 			t.Errorf("No pods matched the selector")
 			return
@@ -72,7 +72,7 @@ func Test_ServiceDisruptor(t *testing.T) {
 				ErrorCode: 500,
 			}
 			httpOptions := disruptors.HTTPDisruptionOptions{}
-			err := disruptor.InjectHTTPFaults(fault, 10 * time.Second, httpOptions)
+			err := disruptor.InjectHTTPFaults(context.TODO(), fault, 10 * time.Second, httpOptions)
 			if err != nil {
 				t.Errorf("error injecting fault: %v", err)
 			}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -39,15 +39,16 @@ func buildObject(rt *goja.Runtime, value interface{}) (*goja.Object, error) {
 	return obj, nil
 }
 
-// jsDisruptor implements the JS interface for PodDisruptor
+// jsDisruptor implements the JS interface for Disruptor
 type jsDisruptor struct {
-	rt *goja.Runtime
+	ctx context.Context // this context controls ths object's lifecycle
+	rt  *goja.Runtime
 	disruptors.Disruptor
 }
 
 // Targets is a proxy method. Validates parameters and delegates to the PodDisruptor method
 func (p *jsDisruptor) Targets() goja.Value {
-	targets, err := p.Disruptor.Targets()
+	targets, err := p.Disruptor.Targets(p.ctx)
 	if err != nil {
 		common.Throw(p.rt, fmt.Errorf("error getting kubernetes config path: %w", err))
 	}
@@ -55,9 +56,10 @@ func (p *jsDisruptor) Targets() goja.Value {
 	return p.rt.ToValue(targets)
 }
 
-// jsProtocolFaultInjector implements the JS interface for PodDisruptor
+// jsProtocolFaultInjector implements the JS interface for jsProtocolFaultInjector
 type jsProtocolFaultInjector struct {
-	rt *goja.Runtime
+	ctx context.Context // this context controls ths object's lifecycle
+	rt  *goja.Runtime
 	disruptors.ProtocolFaultInjector
 }
 
@@ -87,7 +89,7 @@ func (p *jsProtocolFaultInjector) InjectHTTPFaults(args ...goja.Value) {
 		}
 	}
 
-	err = p.ProtocolFaultInjector.InjectHTTPFaults(fault, duration, opts)
+	err = p.ProtocolFaultInjector.InjectHTTPFaults(p.ctx, fault, duration, opts)
 	if err != nil {
 		common.Throw(p.rt, fmt.Errorf("error injecting fault: %w", err))
 	}
@@ -119,7 +121,7 @@ func (p *jsProtocolFaultInjector) InjectGrpcFaults(args ...goja.Value) {
 		}
 	}
 
-	err = p.ProtocolFaultInjector.InjectGrpcFaults(fault, duration, opts)
+	err = p.ProtocolFaultInjector.InjectGrpcFaults(p.ctx, fault, duration, opts)
 	if err != nil {
 		common.Throw(p.rt, fmt.Errorf("error injecting fault: %w", err))
 	}
@@ -131,13 +133,19 @@ type jsPodDisruptor struct {
 }
 
 // buildJsPodDisruptor builds a goja object that implements the PodDisruptor API
-func buildJsPodDisruptor(rt *goja.Runtime, disruptor disruptors.PodDisruptor) (*goja.Object, error) {
+func buildJsPodDisruptor(
+	ctx context.Context,
+	rt *goja.Runtime,
+	disruptor disruptors.PodDisruptor,
+) (*goja.Object, error) {
 	d := &jsPodDisruptor{
 		jsDisruptor: jsDisruptor{
+			ctx:       ctx,
 			rt:        rt,
 			Disruptor: disruptor,
 		},
 		jsProtocolFaultInjector: jsProtocolFaultInjector{
+			ctx:                   ctx,
 			rt:                    rt,
 			ProtocolFaultInjector: disruptor,
 		},
@@ -152,13 +160,19 @@ type jsServiceDisruptor struct {
 }
 
 // buildJsServiceDisruptor builds a goja object that implements the ServiceDisruptor API
-func buildJsServiceDisruptor(rt *goja.Runtime, disruptor disruptors.ServiceDisruptor) (*goja.Object, error) {
+func buildJsServiceDisruptor(
+	ctx context.Context,
+	rt *goja.Runtime,
+	disruptor disruptors.ServiceDisruptor,
+) (*goja.Object, error) {
 	d := &jsServiceDisruptor{
 		jsDisruptor: jsDisruptor{
+			ctx:       ctx,
 			rt:        rt,
 			Disruptor: disruptor,
 		},
 		jsProtocolFaultInjector: jsProtocolFaultInjector{
+			ctx:                   ctx,
 			rt:                    rt,
 			ProtocolFaultInjector: disruptor,
 		},
@@ -168,6 +182,7 @@ func buildJsServiceDisruptor(rt *goja.Runtime, disruptor disruptors.ServiceDisru
 }
 
 // NewPodDisruptor creates an instance of a PodDisruptor
+// The context passed to this constructor is expected to control the lifecycle of the PodDisruptor
 func NewPodDisruptor(
 	ctx context.Context,
 	rt *goja.Runtime,
@@ -198,7 +213,7 @@ func NewPodDisruptor(
 		return nil, fmt.Errorf("error creating PodDisruptor: %w", err)
 	}
 
-	obj, err := buildJsPodDisruptor(rt, disruptor)
+	obj, err := buildJsPodDisruptor(ctx, rt, disruptor)
 	if err != nil {
 		return nil, fmt.Errorf("error creating PodDisruptor: %w", err)
 	}
@@ -207,6 +222,7 @@ func NewPodDisruptor(
 }
 
 // NewServiceDisruptor creates an instance of a ServiceDisruptor and returns it as a goja object
+// The context passed to this constructor is expected to control the lifecycle of the ServiceDisruptor
 func NewServiceDisruptor(
 	ctx context.Context,
 	rt *goja.Runtime,
@@ -243,7 +259,7 @@ func NewServiceDisruptor(
 		return nil, fmt.Errorf("error creating ServiceDisruptor: %w", err)
 	}
 
-	obj, err := buildJsServiceDisruptor(rt, disruptor)
+	obj, err := buildJsServiceDisruptor(ctx, rt, disruptor)
 	if err != nil {
 		return nil, fmt.Errorf("error creating ServiceDisruptor: %w", err)
 	}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -2,6 +2,7 @@
 // allowing for validations and type conversions when needed
 //
 // The implementation of the JS API follows the design described in
+// https://github.com/grafana/xk6-disruptor/blob/fix-context-usage/docs/01-development/design-docs/002-js-api-implementation.md
 package api
 
 import (

--- a/pkg/disruptors/controller_test.go
+++ b/pkg/disruptors/controller_test.go
@@ -83,7 +83,7 @@ func Test_InjectAgent(t *testing.T) {
 				tc.timeout,
 			)
 
-			err := controller.InjectDisruptorAgent()
+			err := controller.InjectDisruptorAgent(context.TODO())
 			if tc.expectError && err == nil {
 				t.Errorf("should had failed")
 				return
@@ -188,7 +188,7 @@ func Test_ExecCommand(t *testing.T) {
 			)
 
 			executor.SetResult(tc.stdout, tc.stderr, tc.err)
-			err := controller.ExecCommand(tc.command)
+			err := controller.ExecCommand(context.TODO(), tc.command)
 			if tc.expectError && err == nil {
 				t.Errorf("should had failed")
 				return

--- a/pkg/disruptors/disruptor.go
+++ b/pkg/disruptors/disruptor.go
@@ -1,7 +1,9 @@
 package disruptors
 
+import "context"
+
 // Disruptor defines the generic interface implemented by all disruptors
 type Disruptor interface {
 	// Targets returns the list of targets for the disruptor
-	Targets() ([]string, error)
+	Targets(ctx context.Context) ([]string, error)
 }

--- a/pkg/disruptors/pod.go
+++ b/pkg/disruptors/pod.go
@@ -28,7 +28,6 @@ type PodDisruptorOptions struct {
 
 // podDisruptor is an instance of a PodDisruptor initialized with a list ot target pods
 type podDisruptor struct {
-	ctx        context.Context
 	controller AgentController
 }
 
@@ -85,41 +84,42 @@ func NewPodDisruptor(
 		targets,
 		options.InjectTimeout,
 	)
-	err = controller.InjectDisruptorAgent()
+	err = controller.InjectDisruptorAgent(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	return &podDisruptor{
-		ctx:        ctx,
 		controller: controller,
 	}, nil
 }
 
 // Targets retrieves the list of target pods for the given PodSelector
-func (d *podDisruptor) Targets() ([]string, error) {
-	return d.controller.Targets()
+func (d *podDisruptor) Targets(ctx context.Context) ([]string, error) {
+	return d.controller.Targets(ctx)
 }
 
 // InjectHTTPFault injects faults in the http requests sent to the disruptor's targets
 func (d *podDisruptor) InjectHTTPFaults(
+	ctx context.Context,
 	fault HTTPFault,
 	duration time.Duration,
 	options HTTPDisruptionOptions,
 ) error {
 	cmd := buildHTTPFaultCmd(fault, duration, options)
 
-	err := d.controller.ExecCommand(cmd)
+	err := d.controller.ExecCommand(ctx, cmd)
 	return err
 }
 
 // InjectGrpcFaults injects faults in the grpc requests sent to the disruptor's targets
 func (d *podDisruptor) InjectGrpcFaults(
+	ctx context.Context,
 	fault GrpcFault,
 	duration time.Duration,
 	options GrpcDisruptionOptions,
 ) error {
 	cmd := buildGrpcFaultCmd(fault, duration, options)
-	err := d.controller.ExecCommand(cmd)
+	err := d.controller.ExecCommand(ctx, cmd)
 	return err
 }

--- a/pkg/disruptors/pod_test.go
+++ b/pkg/disruptors/pod_test.go
@@ -16,20 +16,20 @@ type fakeAgentController struct {
 	executor  *process.FakeExecutor
 }
 
-func (f *fakeAgentController) Targets() ([]string, error) {
+func (f *fakeAgentController) Targets(ctx context.Context) ([]string, error) {
 	return f.targets, nil
 }
 
-func (f *fakeAgentController) InjectDisruptorAgent() error {
+func (f *fakeAgentController) InjectDisruptorAgent(ctx context.Context) error {
 	return nil
 }
 
-func (f *fakeAgentController) ExecCommand(cmd []string) error {
+func (f *fakeAgentController) ExecCommand(ctx context.Context, cmd []string) error {
 	_, err := f.executor.Exec(cmd[0], cmd[1:]...)
 	return err
 }
 
-func (f *fakeAgentController) Visit(visitor func(string) []string) error {
+func (f *fakeAgentController) Visit(ctx context.Context, visitor func(string) []string) error {
 	for _, t := range f.targets {
 		cmd := visitor(t)
 		_, err := f.executor.Exec(cmd[0], cmd[1:]...)
@@ -40,9 +40,8 @@ func (f *fakeAgentController) Visit(visitor func(string) []string) error {
 	return nil
 }
 
-func newPodDisruptorForTesting(ctx context.Context, controller AgentController) PodDisruptor {
+func newPodDisruptorForTesting(controller AgentController) PodDisruptor {
 	return &podDisruptor{
-		ctx:        ctx,
 		controller: controller,
 	}
 }
@@ -177,9 +176,9 @@ func Test_PodHTTPFaultInjection(t *testing.T) {
 				executor:  executor,
 			}
 
-			d := newPodDisruptorForTesting(context.TODO(), controller)
+			d := newPodDisruptorForTesting(controller)
 
-			err := d.InjectHTTPFaults(tc.fault, tc.duration, tc.opts)
+			err := d.InjectHTTPFaults(context.TODO(), tc.fault, tc.duration, tc.opts)
 
 			if tc.expectError && err != nil {
 				return
@@ -334,9 +333,9 @@ func Test_PodGrpcPFaultInjection(t *testing.T) {
 				executor:  executor,
 			}
 
-			d := newPodDisruptorForTesting(context.TODO(), controller)
+			d := newPodDisruptorForTesting(controller)
 
-			err := d.InjectGrpcFaults(tc.fault, tc.duration, tc.opts)
+			err := d.InjectGrpcFaults(context.TODO(), tc.fault, tc.duration, tc.opts)
 
 			if tc.expectError && err != nil {
 				return

--- a/pkg/disruptors/protocol.go
+++ b/pkg/disruptors/protocol.go
@@ -1,15 +1,18 @@
 package disruptors
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 // ProtocolFaultInjector defines the methods for injecting protocol faults
 type ProtocolFaultInjector interface {
 	// InjectHTTPFault injects faults in the HTTP requests sent to the disruptor's targets
 	// for the specified duration
-	InjectHTTPFaults(fault HTTPFault, duration time.Duration, options HTTPDisruptionOptions) error
+	InjectHTTPFaults(ctx context.Context, fault HTTPFault, duration time.Duration, options HTTPDisruptionOptions) error
 	// InjectGrpcFault injects faults in the grpc requests sent to the disruptor's targets
 	// for the specified duration
-	InjectGrpcFaults(fault GrpcFault, duration time.Duration, options GrpcDisruptionOptions) error
+	InjectGrpcFaults(ctx context.Context, fault GrpcFault, duration time.Duration, options GrpcDisruptionOptions) error
 }
 
 // HTTPDisruptionOptions defines options for the injection of HTTP faults in a target pod


### PR DESCRIPTION
# Description

Remove contexts stored in structs in the disruptors. The VU context is however still stored in the js API struct's because the lifecycle of the API objects (e.g. PodDisruptor, ServiceDisruptor) Should be the same than the lifecycle of the VU's context and there's no need to renew it during the lifecycle of these objects.

# Checklist:

- [x] My code follows the coding style of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
