### PR TITLE
Allow running proxy without traffic redirect

### DIFF
--- a/cmd/agent/commands/grpc.go
+++ b/cmd/agent/commands/grpc.go
@@ -7,23 +7,37 @@ import (
 	"github.com/grafana/xk6-disruptor/pkg/agent/protocol"
 	"github.com/grafana/xk6-disruptor/pkg/agent/protocol/grpc"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
+
+func buildGrpcDisruptionFlags(disruption *grpc.Disruption) *pflag.FlagSet {
+	flags := pflag.NewFlagSet("gRPC Disruption", pflag.ContinueOnError)
+
+	flags.DurationVarP(&disruption.AverageDelay, "average-delay", "a", 0, "average request delay")
+	flags.DurationVarP(&disruption.DelayVariation, "delay-variation", "v", 0, "variation in request delay")
+	flags.Int32VarP(&disruption.StatusCode, "status", "s", 0, "status code")
+	flags.Float32VarP(&disruption.ErrorRate, "rate", "r", 0, "error rate")
+	flags.StringVarP(&disruption.StatusMessage, "message", "m", "", "error message for injected faults")
+	flags.StringSliceVarP(&disruption.Excluded, "exclude", "x", []string{}, "comma-separated list of grpc services"+
+		" to be excluded from disruption")
+
+	return flags
+}
 
 // BuildGrpcCmd returns a cobra command with the specification of the grpc command
 func BuildGrpcCmd() *cobra.Command {
 	disruption := grpc.Disruption{}
 	var duration time.Duration
-	var port uint
-	var target uint
-	var iface string
+	config := protocol.DisruptorConfig{}
+	upstreamHost := "127.0.0.1"
 	cmd := &cobra.Command{
 		Use:   "grpc",
 		Short: "grpc disruptor",
 		Long: "Disrupts grpc request by introducing delays and errors." +
 			" Requires NET_ADMIM capabilities for setting iptable rules.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			listenAddress := fmt.Sprintf(":%d", port)
-			upstreamAddress := fmt.Sprintf(":%d", target)
+			upstreamAddress := fmt.Sprintf("%s:%d", upstreamHost, config.TargetPort)
+			listenAddress := fmt.Sprintf(":%d", config.RedirectPort)
 			proxy, err := grpc.NewProxy(
 				grpc.ProxyConfig{
 					ListenAddress:   listenAddress,
@@ -34,11 +48,7 @@ func BuildGrpcCmd() *cobra.Command {
 			}
 
 			disruptor, err := protocol.NewDisruptor(
-				protocol.DisruptorConfig{
-					TargetPort:   target,
-					RedirectPort: port,
-					Iface:        iface,
-				},
+				config,
 				proxy,
 			)
 			if err != nil {
@@ -49,16 +59,46 @@ func BuildGrpcCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().DurationVarP(&duration, "duration", "d", 0, "duration of the disruptions")
-	cmd.Flags().DurationVarP(&disruption.AverageDelay, "average-delay", "a", 0, "average request delay")
-	cmd.Flags().DurationVarP(&disruption.DelayVariation, "delay-variation", "v", 0, "variation in request delay")
-	cmd.Flags().Int32VarP(&disruption.StatusCode, "status", "s", 0, "status code")
-	cmd.Flags().Float32VarP(&disruption.ErrorRate, "rate", "r", 0, "error rate")
-	cmd.Flags().StringVarP(&disruption.StatusMessage, "message", "m", "", "error message for injected faults")
-	cmd.Flags().StringVarP(&iface, "interface", "i", "eth0", "interface to disrupt")
+
+	// add flags for HTTP disruption
+	cmd.Flags().AddFlagSet(buildGrpcDisruptionFlags(&disruption))
+
+	// add flags for traffic redirection
+	cmd.Flags().StringVarP(&config.Iface, "interface", "i", "eth0", "interface to disrupt")
+	cmd.Flags().UintVarP(&config.RedirectPort, "port", "p", 8080, "port the proxy will listen to")
+	cmd.Flags().UintVarP(&config.TargetPort, "target", "t", 80, "port the proxy will redirect request to")
+
+	return cmd
+}
+
+// BuildGrpcProxyCmd returns a cobra command with the specification of the grpc-proxy command
+func BuildGrpcProxyCmd() *cobra.Command {
+	disruption := grpc.Disruption{}
+	var port uint
+	upstreamHost := ""
+	cmd := &cobra.Command{
+		Use:   "grpc-proxy",
+		Short: "grpc disruptor proxy",
+		Long:  "Proxy that disrupts gRPC request by introducing delays and errors.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			listenAddress := fmt.Sprintf(":%d", port)
+			proxy, err := grpc.NewProxy(
+				grpc.ProxyConfig{
+					ListenAddress:   listenAddress,
+					UpstreamAddress: upstreamHost,
+				}, disruption)
+			if err != nil {
+				return err
+			}
+
+			err = proxy.Start()
+			return err
+		},
+	}
+
+	cmd.Flags().AddFlagSet(buildGrpcDisruptionFlags(&disruption))
 	cmd.Flags().UintVarP(&port, "port", "p", 8080, "port the proxy will listen to")
-	cmd.Flags().UintVarP(&target, "target", "t", 80, "port the proxy will redirect request to")
-	cmd.Flags().StringSliceVarP(&disruption.Excluded, "exclude", "x", []string{}, "comma-separated list of grpc services"+
-		" to be excluded from disruption")
+	cmd.Flags().StringVarP(&upstreamHost, "upstream", "u", "", "upstream host to redirect to")
 
 	return cmd
 }

--- a/cmd/agent/commands/http.go
+++ b/cmd/agent/commands/http.go
@@ -7,23 +7,37 @@ import (
 	"github.com/grafana/xk6-disruptor/pkg/agent/protocol"
 	"github.com/grafana/xk6-disruptor/pkg/agent/protocol/http"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
+
+func buildHTTPDisruptionFlags(disruption *http.Disruption) *pflag.FlagSet {
+	flags := pflag.NewFlagSet("HTTP Disruption", pflag.ContinueOnError)
+
+	flags.DurationVarP(&disruption.AverageDelay, "average-delay", "a", 0, "average request delay")
+	flags.DurationVarP(&disruption.DelayVariation, "delay-variation", "v", 0, "variation in request delay")
+	flags.UintVarP(&disruption.ErrorCode, "error", "e", 0, "error code")
+	flags.Float32VarP(&disruption.ErrorRate, "rate", "r", 0, "error rate")
+	flags.StringVarP(&disruption.ErrorBody, "body", "b", "", "body for injected faults")
+	flags.StringSliceVarP(&disruption.Excluded, "exclude", "x", []string{}, "comma-separated list of path(s)"+
+		" to be excluded from disruption")
+
+	return flags
+}
 
 // BuildHTTPCmd returns a cobra command with the specification of the http command
 func BuildHTTPCmd() *cobra.Command {
 	disruption := http.Disruption{}
+	config := protocol.DisruptorConfig{}
+	upstreamHost := "127.0.0.1"
 	var duration time.Duration
-	var port uint
-	var target uint
-	var iface string
 	cmd := &cobra.Command{
 		Use:   "http",
 		Short: "http disruptor",
-		Long: "Disrupts http request by introducing delays and errors." +
+		Long: "Installs a transparent proxy that disrupts http request by introducing delays and errors." +
 			" Requires NET_ADMIM capabilities for setting iptable rules.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			listenAddress := fmt.Sprintf(":%d", port)
-			upstreamAddress := fmt.Sprintf("http://127.0.0.1:%d", target)
+			upstreamAddress := fmt.Sprintf("http://%s:%d", upstreamHost, config.TargetPort)
+			listenAddress := fmt.Sprintf(":%d", config.RedirectPort)
 			proxy, err := http.NewProxy(
 				http.ProxyConfig{
 					ListenAddress:   listenAddress,
@@ -34,11 +48,7 @@ func BuildHTTPCmd() *cobra.Command {
 			}
 
 			disruptor, err := protocol.NewDisruptor(
-				protocol.DisruptorConfig{
-					TargetPort:   target,
-					RedirectPort: port,
-					Iface:        iface,
-				},
+				config,
 				proxy,
 			)
 			if err != nil {
@@ -49,16 +59,46 @@ func BuildHTTPCmd() *cobra.Command {
 		},
 	}
 	cmd.Flags().DurationVarP(&duration, "duration", "d", 0, "duration of the disruptions")
-	cmd.Flags().DurationVarP(&disruption.AverageDelay, "average-delay", "a", 0, "average request delay")
-	cmd.Flags().DurationVarP(&disruption.DelayVariation, "delay-variation", "v", 0, "variation in request delay")
-	cmd.Flags().UintVarP(&disruption.ErrorCode, "error", "e", 0, "error code")
-	cmd.Flags().Float32VarP(&disruption.ErrorRate, "rate", "r", 0, "error rate")
-	cmd.Flags().StringVarP(&disruption.ErrorBody, "body", "b", "", "body for injected faults")
-	cmd.Flags().StringSliceVarP(&disruption.Excluded, "exclude", "x", []string{}, "comma-separated list of path(s)"+
-		" to be excluded from disruption")
-	cmd.Flags().StringVarP(&iface, "interface", "i", "eth0", "interface to disrupt")
+
+	// add flags for HTTP disruption
+	cmd.Flags().AddFlagSet(buildHTTPDisruptionFlags(&disruption))
+
+	// add flags for traffic redirection
+	cmd.Flags().StringVarP(&config.Iface, "interface", "i", "eth0", "interface to disrupt")
+	cmd.Flags().UintVarP(&config.TargetPort, "port", "p", 8080, "port the proxy will listen to")
+	cmd.Flags().UintVarP(&config.TargetPort, "target", "t", 80, "port the proxy will redirect request to")
+
+	return cmd
+}
+
+// BuildHTTPProxyCmd returns a cobra command with the specification of the http-proxy command
+func BuildHTTPProxyCmd() *cobra.Command {
+	disruption := http.Disruption{}
+	var port uint
+	upstreamHost := ""
+	cmd := &cobra.Command{
+		Use:   "http-proxy",
+		Short: "http disruptor proxy ",
+		Long:  "Proxy that disrupts http request by introducing delays and errors.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			listenAddress := fmt.Sprintf(":%d", port)
+			proxy, err := http.NewProxy(
+				http.ProxyConfig{
+					ListenAddress:   listenAddress,
+					UpstreamAddress: upstreamHost,
+				}, disruption)
+			if err != nil {
+				return err
+			}
+
+			err = proxy.Start()
+			return err
+		},
+	}
+
+	cmd.Flags().AddFlagSet(buildHTTPDisruptionFlags(&disruption))
 	cmd.Flags().UintVarP(&port, "port", "p", 8080, "port the proxy will listen to")
-	cmd.Flags().UintVarP(&target, "target", "t", 80, "port the proxy will redirect request to")
+	cmd.Flags().StringVarP(&upstreamHost, "upstream", "u", "127.0.0.1:80", "upstream host to redirect to")
 
 	return cmd
 }

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -112,7 +112,9 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&traceFileName, "trace-file", "trace.out", "tracing output file")
 
 	rootCmd.AddCommand(commands.BuildHTTPCmd())
+	rootCmd.AddCommand(commands.BuildHTTPProxyCmd())
 	rootCmd.AddCommand(commands.BuildGrpcCmd())
+	rootCmd.AddCommand(commands.BuildGrpcProxyCmd())
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/docs/01-development/01-contributing.md
+++ b/docs/01-development/01-contributing.md
@@ -72,13 +72,15 @@ If using `minikube` the following command loads the image into the cluster:
 minikube image load ghcr.io/grafana/xk6-disruptor-agent:latest
 ```
 
-### Debugging the disruptor agent
+## Debugging the disruptor agent
 
 The disruptor agent is the responsible for injecting faults in the targets (e.g. pods). The agent is injected into the targets by the xk6-disruptor extension as an ephemeral container with the name `xk6-agent`.
 
-You can debug the agent by running it manually at a target.
+### Running manually
 
-First enter the agent's container using an interactive console:
+Once the agent is injected in a target (using the [xk6-disruptor API](https://k6.io/docs/javascript-api/xk6-disruptor/api/) in a k6 test), you can debug the agent by running it manually.
+
+First enter the agent's container at the target pod using an interactive console:
 
 ```bash
 kubectl exec -it <target pod> -c xk6-agent -- sh
@@ -90,17 +92,28 @@ Once you get the prompt, you can inject faults by running the `xk6-disruptor-age
 xk6-disruptor-agent [arguments for fault injection]
 ```
 
+### Running as a proxy
+
+When debugging issues with the protocol disruptor it is also possible to run the agent locally in your machine as a proxy that redirects the traffic to an upstream destination, using k6 to generate a test load to the agent.
+
+This approach is particularly useful for debugging issues with the protocols or profiling the agent to find memory leaks.
+
+Check the agent help for a list of proxies available.
+
+### Tracing and profiling
+
 In order to facilitate debugging `xk6-disruptor-agent` offers options for generating execution traces:
 * `--trace`: generate traces. The `--trace-file` option allows specifying the output file for traces (default `trace.out`)
 * `--cpu-profile`: generate CPU profiling information. The `--cpu-profile-file` option allows specifying the output file for profile information (default `cpu.pprof`)
 * `--mem-profile`: generate memory profiling information. By default, it sets the [memory profile rate](https://pkg.go.dev/runtime#pkg-variables) to `1`, which will profile every allocation. This rate can be controlled using the `--mem-profile-rate` option. The `--mem-profile-file` option allows specifying the output file for profile information (default `mem.pprof`)
 
-In order to analyze those files you have to copy them from the target pod to your local machine. For example, for copying the `trace.out` file:
+If you run the [disrupor manually](#running-manually) in a pod you have to copy them from the target pod to your local machine. For example, for copying the `trace.out` file:
+
 ```bash
 kubectl cp <target pod>:trace.out -c xk6-agent trace.out
 ```
 
-### e2e tests
+## e2e tests
 
 End to end tests are meant to test the components of the project in a test environment without mocks.
 These tests are slow and resource consuming. To prevent them to be executed as part of the `test` target

--- a/pkg/agent/protocol/protocol.go
+++ b/pkg/agent/protocol/protocol.go
@@ -61,18 +61,6 @@ func NewDisruptor(
 	config DisruptorConfig,
 	proxy Proxy,
 ) (Disruptor, error) {
-	if config.RedirectPort == 0 {
-		return nil, fmt.Errorf("redirect port must be valid tcp port")
-	}
-
-	if config.TargetPort == 0 {
-		return nil, fmt.Errorf("target port must be valid tcp port")
-	}
-
-	if config.Iface == "" {
-		return nil, fmt.Errorf("disruption must specify an interface")
-	}
-
 	if proxy == nil {
 		return nil, fmt.Errorf("proxy cannot be null")
 	}
@@ -111,8 +99,8 @@ func (d *disruptor) Apply(duration time.Duration) error {
 	}
 
 	// On termination, restore traffic and stop proxy
+	// Ignore errors when stopping. Nothing to do
 	defer func() {
-		// ignore errors when stopping. Nothing to do
 		_ = d.redirector.Stop()
 		_ = d.proxy.Stop()
 	}()


### PR DESCRIPTION
# Description

Adds options to the agent to allow running protocol disruptors as a regular proxy (without transparent traffic redirection) to an upstream host.

Fixes #167 

# Checklist:

- [x] My code follows the coding style of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
