### PR TITLE
Add transparent proxy option

### DIFF
--- a/cmd/agent/commands/http.go
+++ b/cmd/agent/commands/http.go
@@ -16,14 +16,18 @@ func BuildHTTPCmd() *cobra.Command {
 	var port uint
 	var target uint
 	var iface string
+	upstreamHost := "localhost"
+	transparent := true
+
 	cmd := &cobra.Command{
 		Use:   "http",
 		Short: "http disruptor",
 		Long: "Disrupts http request by introducing delays and errors." +
-			" Requires NET_ADMIM capabilities for setting iptable rules.",
+			" When running as a transparent proxy requires NET_ADMIM capabilities for setting" +
+			" iptable rules.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			listenAddress := fmt.Sprintf(":%d", port)
-			upstreamAddress := fmt.Sprintf("http://127.0.0.1:%d", target)
+			upstreamAddress := fmt.Sprintf("http://%s:%d", upstreamHost, target)
 			proxy, err := http.NewProxy(
 				http.ProxyConfig{
 					ListenAddress:   listenAddress,
@@ -31,6 +35,12 @@ func BuildHTTPCmd() *cobra.Command {
 				}, disruption)
 			if err != nil {
 				return err
+			}
+
+			// run as a regular proxy
+			if !transparent {
+				// TODO: pass a context with a timeout using the duration argument
+				return proxy.Start()
 			}
 
 			disruptor, err := protocol.NewDisruptor(
@@ -56,6 +66,7 @@ func BuildHTTPCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&disruption.ErrorBody, "body", "b", "", "body for injected faults")
 	cmd.Flags().StringSliceVarP(&disruption.Excluded, "exclude", "x", []string{}, "comma-separated list of path(s)"+
 		" to be excluded from disruption")
+	cmd.Flags().BoolVar(&transparent, "transparent", true, "run as transparent proxy")
 	cmd.Flags().StringVarP(&iface, "interface", "i", "eth0", "interface to disrupt")
 	cmd.Flags().UintVarP(&port, "port", "p", 8080, "port the proxy will listen to")
 	cmd.Flags().UintVarP(&target, "target", "t", 80, "port the proxy will redirect request to")

--- a/docs/01-development/01-contributing.md
+++ b/docs/01-development/01-contributing.md
@@ -72,13 +72,15 @@ If using `minikube` the following command loads the image into the cluster:
 minikube image load ghcr.io/grafana/xk6-disruptor-agent:latest
 ```
 
-### Debugging the disruptor agent
+## Debugging the disruptor agent
 
 The disruptor agent is the responsible for injecting faults in the targets (e.g. pods). The agent is injected into the targets by the xk6-disruptor extension as an ephemeral container with the name `xk6-agent`.
 
-You can debug the agent by running it manually at a target.
+### Running manually
 
-First enter the agent's container using an interactive console:
+Once the agent is injected in a target (using the [xk6-disruptor API](https://k6.io/docs/javascript-api/xk6-disruptor/api/) in a k6 test), you can debug the agent by running it manually.
+
+First enter the agent's container at the target pod using an interactive console:
 
 ```bash
 kubectl exec -it <target pod> -c xk6-agent -- sh
@@ -90,17 +92,32 @@ Once you get the prompt, you can inject faults by running the `xk6-disruptor-age
 xk6-disruptor-agent [arguments for fault injection]
 ```
 
+### Running as a proxy
+
+When debugging issues with the protocol disruptor it is also possible to run the agent locally in your machine as a proxy that redirects the traffic to an upstream destination, using k6 to generate a test load to the agent.
+
+This approach is particularly useful for debugging issues with the protocols or profiling the agent to find memory leaks.
+
+For running the protocol fault injection as a (non-transparent) proxy use the `--transparent=false` option:
+
+```bash
+xk6-disruptor-agent <protocol> --transparent=false [arguments for fault injection]
+```
+
+### Tracing and profiling
+
 In order to facilitate debugging `xk6-disruptor-agent` offers options for generating execution traces:
 * `--trace`: generate traces. The `--trace-file` option allows specifying the output file for traces (default `trace.out`)
 * `--cpu-profile`: generate CPU profiling information. The `--cpu-profile-file` option allows specifying the output file for profile information (default `cpu.pprof`)
 * `--mem-profile`: generate memory profiling information. By default, it sets the [memory profile rate](https://pkg.go.dev/runtime#pkg-variables) to `1`, which will profile every allocation. This rate can be controlled using the `--mem-profile-rate` option. The `--mem-profile-file` option allows specifying the output file for profile information (default `mem.pprof`)
 
-In order to analyze those files you have to copy them from the target pod to your local machine. For example, for copying the `trace.out` file:
+If you run the [disrupor manually](#running-manually) in a pod you have to copy them from the target pod to your local machine. For example, for copying the `trace.out` file:
+
 ```bash
 kubectl cp <target pod>:trace.out -c xk6-agent trace.out
 ```
 
-### e2e tests
+## e2e tests
 
 End to end tests are meant to test the components of the project in a test environment without mocks.
 These tests are slow and resource consuming. To prevent them to be executed as part of the `test` target

--- a/docs/01-development/01-contributing.md
+++ b/docs/01-development/01-contributing.md
@@ -92,11 +92,19 @@ Once you get the prompt, you can inject faults by running the `xk6-disruptor-age
 xk6-disruptor-agent [arguments for fault injection]
 ```
 
+### Running locally
+
+It is possible to run the agent locally in your machine using the following command:
+
+```bash
+xk6-disruptor-agent [arguments for fault injection]
+```
+
+This is useful for debugging and also to facilitate [CPU and memory profiling](#tracing-and-profiling)
+
 ### Running as a proxy
 
-When debugging issues with the protocol disruptor it is also possible to run the agent locally in your machine as a proxy that redirects the traffic to an upstream destination, using k6 to generate a test load to the agent.
-
-This approach is particularly useful for debugging issues with the protocols or profiling the agent to find memory leaks.
+When debugging issues with protocols, you can run the agent in your local machine as a proxy that redirects the traffic to an upstream destination.
 
 For running the protocol fault injection as a (non-transparent) proxy use the `--transparent=false` option:
 


### PR DESCRIPTION
# Description

Adds options to the agent to allow running protocol disruptors as a regular proxy (without transparent traffic redirection) to an upstream host.

Fixes https://github.com/grafana/xk6-disruptor/issues/167

Note: Alternative implementation to #168 

# Checklist:

- [x] My code follows the coding style of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
