### PR TITLE
Echo port number in error message

### DIFF
--- a/pkg/iptables/iptables.go
+++ b/pkg/iptables/iptables.go
@@ -54,7 +54,11 @@ func newTrafficRedirectorWithConfig(
 	}
 
 	if tr.DestinationPort == tr.RedirectPort {
-		return nil, fmt.Errorf("the DestinationPort (%d) and RedirectPort (%d) must be different", tr.DestinationPort, tr.RedirectPort)
+		return nil, fmt.Errorf(
+			"the DestinationPort (%d) and RedirectPort (%d) must be different",
+			tr.DestinationPort,
+			tr.RedirectPort,
+		)
 	}
 
 	if tr.Iface == "" {

--- a/pkg/iptables/iptables.go
+++ b/pkg/iptables/iptables.go
@@ -54,7 +54,7 @@ func newTrafficRedirectorWithConfig(
 	}
 
 	if tr.DestinationPort == tr.RedirectPort {
-		return nil, fmt.Errorf("the DestinationPort and RedirectPort must be different")
+		return nil, fmt.Errorf("the DestinationPort (%d) and RedirectPort (%d) must be different", tr.DestinationPort, tr.RedirectPort)
 	}
 
 	if tr.Iface == "" {


### PR DESCRIPTION
# Description

When attempting to fault inject a service listening on port 8080, the disruptor fails with the following message:

```
ERRO[0006] GoError: error injecting fault: error invoking agent: command terminated with exit code 1
the DestinationPort and RedirectPort must be different
```

However, this error is not very actionable, as most likely the user has specified neither of those. By echoing the port numbers, we give the user some more context about which port is colliding.

# Checklist:

- [x] My code follows the coding style of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
