### PR TITLE
Abstract exec environment

### DIFF
--- a/cmd/agent/commands/grpc.go
+++ b/cmd/agent/commands/grpc.go
@@ -6,11 +6,12 @@ import (
 
 	"github.com/grafana/xk6-disruptor/pkg/agent/protocol"
 	"github.com/grafana/xk6-disruptor/pkg/agent/protocol/grpc"
+	"github.com/grafana/xk6-disruptor/pkg/runtime"
 	"github.com/spf13/cobra"
 )
 
 // BuildGrpcCmd returns a cobra command with the specification of the grpc command
-func BuildGrpcCmd() *cobra.Command {
+func BuildGrpcCmd(env runtime.Environment) *cobra.Command {
 	disruption := grpc.Disruption{}
 	var duration time.Duration
 	var port uint
@@ -44,6 +45,7 @@ func BuildGrpcCmd() *cobra.Command {
 			}
 
 			disruptor, err := protocol.NewDisruptor(
+				env.Executor(),
 				protocol.DisruptorConfig{
 					TargetPort:   target,
 					RedirectPort: port,

--- a/cmd/agent/commands/http.go
+++ b/cmd/agent/commands/http.go
@@ -6,11 +6,12 @@ import (
 
 	"github.com/grafana/xk6-disruptor/pkg/agent/protocol"
 	"github.com/grafana/xk6-disruptor/pkg/agent/protocol/http"
+	"github.com/grafana/xk6-disruptor/pkg/runtime"
 	"github.com/spf13/cobra"
 )
 
 // BuildHTTPCmd returns a cobra command with the specification of the http command
-func BuildHTTPCmd() *cobra.Command {
+func BuildHTTPCmd(env runtime.Environment) *cobra.Command {
 	disruption := http.Disruption{}
 	var duration time.Duration
 	var port uint
@@ -44,6 +45,7 @@ func BuildHTTPCmd() *cobra.Command {
 			}
 
 			disruptor, err := protocol.NewDisruptor(
+				env.Executor(),
 				protocol.DisruptorConfig{
 					TargetPort:   target,
 					RedirectPort: port,

--- a/cmd/agent/commands/root.go
+++ b/cmd/agent/commands/root.go
@@ -1,0 +1,92 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/grafana/xk6-disruptor/pkg/runtime"
+	"github.com/spf13/cobra"
+)
+
+const lockFile = "/var/run/xk6-disruptor"
+
+// returns the path to the lock file
+func getLockPath() string {
+	// get runtime directory for user
+	lockDir := os.Getenv("XDG_RUNTIME_DIR")
+	if lockDir == "" {
+		lockDir = os.TempDir()
+	}
+
+	return path.Join(lockDir, lockFile)
+}
+
+// ensure only one instance of the agent runs
+func lockExecution() error {
+	acquired, err := runtime.Lock(getLockPath())
+	if err != nil {
+		return fmt.Errorf("failed to create lock file %q: %w", getLockPath(), err)
+	}
+	if !acquired {
+		return fmt.Errorf("another disruptor command is already in execution")
+	}
+
+	return nil
+}
+
+
+// BuildRootCmd builds the root command for the agent with all the persistent flags
+func BuildRootCmd() *cobra.Command {
+	profilerConfig := runtime.ProfilerConfig{}
+	var profiler runtime.Profiler
+
+	rootCmd := &cobra.Command{
+		Use:   "xk6-disruptor-agent",
+		Short: "Inject disruptions in a system",
+		Long: "A command for injecting disruptions in a target system.\n" +
+			"It can run as stand-alone process or in a container",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			err := lockExecution()
+			if err != nil {
+				return err
+			}
+
+			profiler, err = runtime.NewProfiler(profilerConfig)
+			if err != nil {
+				return fmt.Errorf("could not create profiler %w", err)
+			}
+
+			err = profiler.Start()
+			if err != nil {
+				return fmt.Errorf("could not start profiler %w", err)
+			}
+
+			return nil
+		},
+		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
+			_ = runtime.Unlock(getLockPath())
+			
+			err := profiler.Stop()
+			if err != nil {
+				return fmt.Errorf("could not stop profiler %w", err)
+			}
+
+			return nil
+		},
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+
+	rootCmd.PersistentFlags().BoolVar(&profilerConfig.CPUProfile, "cpu-profile", false, "profile agent execution")
+	rootCmd.PersistentFlags().StringVar(&profilerConfig.CPUProfileFileName, "cpu-profile-file", "cpu.pprof",
+		"cpu profiling output file")
+	rootCmd.PersistentFlags().BoolVar(&profilerConfig.MemProfile, "mem-profile", false, "profile agent memory")
+	rootCmd.PersistentFlags().StringVar(&profilerConfig.MemProfileFileName, "mem-profile-file", "mem.pprof",
+		"memory profiling output file")
+	rootCmd.PersistentFlags().IntVar(&profilerConfig.MemProfileRate, "mem-profile-rate", 1, "memory profiling rate")
+	rootCmd.PersistentFlags().BoolVar(&profilerConfig.Trace, "trace", false, "trace agent execution")
+	rootCmd.PersistentFlags().StringVar(&profilerConfig.TraceFileName, "trace-file", "trace.out", "tracing output file")
+
+	return rootCmd
+}

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -10,10 +10,11 @@ import (
 )
 
 func main() {
-	rootCmd := commands.BuildRootCmd(runtime.DefaultEnvironment())
+	env := runtime.DefaultEnvironment()
+	rootCmd := commands.BuildRootCmd(env)
 
-	rootCmd.AddCommand(commands.BuildHTTPCmd())
-	rootCmd.AddCommand(commands.BuildGrpcCmd())
+	rootCmd.AddCommand(commands.BuildHTTPCmd(env))
+	rootCmd.AddCommand(commands.BuildGrpcCmd(env))
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -6,10 +6,11 @@ import (
 	"os"
 
 	"github.com/grafana/xk6-disruptor/cmd/agent/commands"
+	"github.com/grafana/xk6-disruptor/pkg/runtime"
 )
 
 func main() {
-	rootCmd := commands.BuildRootCmd()
+	rootCmd := commands.BuildRootCmd(runtime.DefaultEnvironment())
 
 	rootCmd.AddCommand(commands.BuildHTTPCmd())
 	rootCmd.AddCommand(commands.BuildGrpcCmd())

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -5,9 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	goruntime "runtime"
-	"runtime/pprof"
-	runtimetrace "runtime/trace"
 
 	"github.com/grafana/xk6-disruptor/cmd/agent/commands"
 	"github.com/grafana/xk6-disruptor/pkg/runtime"
@@ -40,17 +37,9 @@ func lockExecution() error {
 	return nil
 }
 
-//nolint:funlen,gocognit
 func main() {
-	cpuProfile := false
-	var cpuProfileFileName string
-	memProfile := false
-	memProfileRate := 1
-	var memProfileFileName string
-	var memProfileFile *os.File
-	trace := false
-	var traceFileName string
-	var traceFile *os.File
+	profilerConfig := runtime.ProfilerConfig{}
+	var profiler runtime.Profiler
 
 	rootCmd := &cobra.Command{
 		Use:   "xk6-disruptor-agent",
@@ -63,58 +52,24 @@ func main() {
 				return err
 			}
 
-			// cpu profiling
-			if cpuProfile {
-				var profileFile *os.File
-				profileFile, err = os.Create(cpuProfileFileName)
-				if err != nil {
-					return fmt.Errorf("error creating CPU profiling file %q: %w", cpuProfileFileName, err)
-				}
-
-				err = pprof.StartCPUProfile(profileFile)
-				if err != nil {
-					return fmt.Errorf("failed to start CPU profiling: %w", err)
-				}
+			profiler, err = runtime.NewProfiler(profilerConfig)
+			if err != nil {
+				return fmt.Errorf("could not create profiler %w", err)
 			}
 
-			// memory profiling
-			if memProfile {
-				memProfileFile, err = os.Create(memProfileFileName)
-				if err != nil {
-					return fmt.Errorf("error creating memory profiling file %q: %w", memProfileFileName, err)
-				}
-
-				goruntime.MemProfileRate = memProfileRate
-			}
-
-			// trace program execution
-			if trace {
-				traceFile, err = os.Create(traceFileName)
-				if err != nil {
-					return fmt.Errorf("failed to create trace output file %q: %w", traceFileName, err)
-				}
-
-				if err := runtimetrace.Start(traceFile); err != nil {
-					return fmt.Errorf("failed to start trace: %w", err)
-				}
+			err = profiler.Start()
+			if err != nil {
+				return fmt.Errorf("could not start profiler %w", err)
 			}
 
 			return nil
 		},
 		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
 			_ = runtime.Unlock(getLockPath())
-			if cpuProfile {
-				pprof.StopCPUProfile()
-			}
-			if memProfile {
-				err := pprof.Lookup("heap").WriteTo(memProfileFile, 0)
-				if err != nil {
-					return fmt.Errorf("failed to write memory profile to file %q: %w", memProfileFileName, err)
-				}
-			}
-			if trace {
-				runtimetrace.Stop()
-				_ = traceFile.Close()
+
+			err := profiler.Stop()
+			if err != nil {
+				return fmt.Errorf("could not stop profiler %w", err)
 			}
 
 			return nil
@@ -123,15 +78,15 @@ func main() {
 		SilenceErrors: true,
 	}
 
-	rootCmd.PersistentFlags().BoolVar(&cpuProfile, "cpu-profile", false, "profile agent execution")
-	rootCmd.PersistentFlags().StringVar(&cpuProfileFileName, "cpu-profile-file", "cpu.pprof",
+	rootCmd.PersistentFlags().BoolVar(&profilerConfig.CPUProfile, "cpu-profile", false, "profile agent execution")
+	rootCmd.PersistentFlags().StringVar(&profilerConfig.CPUProfileFileName, "cpu-profile-file", "cpu.pprof",
 		"cpu profiling output file")
-	rootCmd.PersistentFlags().BoolVar(&memProfile, "mem-profile", false, "profile agent memory")
-	rootCmd.PersistentFlags().StringVar(&memProfileFileName, "mem-profile-file", "mem.pprof",
+	rootCmd.PersistentFlags().BoolVar(&profilerConfig.MemProfile, "mem-profile", false, "profile agent memory")
+	rootCmd.PersistentFlags().StringVar(&profilerConfig.MemProfileFileName, "mem-profile-file", "mem.pprof",
 		"memory profiling output file")
-	rootCmd.PersistentFlags().IntVar(&memProfileRate, "mem-profile-rate", 1, "memory profiling rate")
-	rootCmd.PersistentFlags().BoolVar(&trace, "trace", false, "trace agent execution")
-	rootCmd.PersistentFlags().StringVar(&traceFileName, "trace-file", "trace.out", "tracing output file")
+	rootCmd.PersistentFlags().IntVar(&profilerConfig.MemProfileRate, "mem-profile-rate", 1, "memory profiling rate")
+	rootCmd.PersistentFlags().BoolVar(&profilerConfig.Trace, "trace", false, "trace agent execution")
+	rootCmd.PersistentFlags().StringVar(&profilerConfig.TraceFileName, "trace-file", "trace.out", "tracing output file")
 
 	rootCmd.AddCommand(commands.BuildHTTPCmd())
 	rootCmd.AddCommand(commands.BuildGrpcCmd())

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -4,89 +4,12 @@ package main
 import (
 	"fmt"
 	"os"
-	"path"
 
 	"github.com/grafana/xk6-disruptor/cmd/agent/commands"
-	"github.com/grafana/xk6-disruptor/pkg/runtime"
-	"github.com/spf13/cobra"
 )
 
-const lockFile = "xk6-disruptor"
-
-// returns the path to the lock file
-func getLockPath() string {
-	// get runtime directory for user
-	lockDir := os.Getenv("XDG_RUNTIME_DIR")
-	if lockDir == "" {
-		lockDir = os.TempDir()
-	}
-
-	return path.Join(lockDir, lockFile)
-}
-
-// ensure only one instance of the agent runs
-func lockExecution() error {
-	acquired, err := runtime.Lock(getLockPath())
-	if err != nil {
-		return fmt.Errorf("failed to create lock file %q: %w", getLockPath(), err)
-	}
-	if !acquired {
-		return fmt.Errorf("another disruptor command is already in execution")
-	}
-
-	return nil
-}
-
 func main() {
-	profilerConfig := runtime.ProfilerConfig{}
-	var profiler runtime.Profiler
-
-	rootCmd := &cobra.Command{
-		Use:   "xk6-disruptor-agent",
-		Short: "Inject disruptions in a system",
-		Long: "A command for injecting disruptions in a target system.\n" +
-			"It can run as stand-alone process or in a container",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			err := lockExecution()
-			if err != nil {
-				return err
-			}
-
-			profiler, err = runtime.NewProfiler(profilerConfig)
-			if err != nil {
-				return fmt.Errorf("could not create profiler %w", err)
-			}
-
-			err = profiler.Start()
-			if err != nil {
-				return fmt.Errorf("could not start profiler %w", err)
-			}
-
-			return nil
-		},
-		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
-			_ = runtime.Unlock(getLockPath())
-
-			err := profiler.Stop()
-			if err != nil {
-				return fmt.Errorf("could not stop profiler %w", err)
-			}
-
-			return nil
-		},
-		SilenceUsage:  true,
-		SilenceErrors: true,
-	}
-
-	rootCmd.PersistentFlags().BoolVar(&profilerConfig.CPUProfile, "cpu-profile", false, "profile agent execution")
-	rootCmd.PersistentFlags().StringVar(&profilerConfig.CPUProfileFileName, "cpu-profile-file", "cpu.pprof",
-		"cpu profiling output file")
-	rootCmd.PersistentFlags().BoolVar(&profilerConfig.MemProfile, "mem-profile", false, "profile agent memory")
-	rootCmd.PersistentFlags().StringVar(&profilerConfig.MemProfileFileName, "mem-profile-file", "mem.pprof",
-		"memory profiling output file")
-	rootCmd.PersistentFlags().IntVar(&profilerConfig.MemProfileRate, "mem-profile-rate", 1, "memory profiling rate")
-	rootCmd.PersistentFlags().BoolVar(&profilerConfig.Trace, "trace", false, "trace agent execution")
-	rootCmd.PersistentFlags().StringVar(&profilerConfig.TraceFileName, "trace-file", "trace.out", "tracing output file")
+	rootCmd := commands.BuildRootCmd()
 
 	rootCmd.AddCommand(commands.BuildHTTPCmd())
 	rootCmd.AddCommand(commands.BuildGrpcCmd())

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"runtime"
+	goruntime "runtime"
 	"runtime/pprof"
 	runtimetrace "runtime/trace"
 
 	"github.com/grafana/xk6-disruptor/cmd/agent/commands"
-	"github.com/grafana/xk6-disruptor/pkg/utils/process"
+	"github.com/grafana/xk6-disruptor/pkg/runtime"
 	"github.com/spf13/cobra"
 )
 
@@ -29,7 +29,7 @@ func getLockPath() string {
 
 // ensure only one instance of the agent runs
 func lockExecution() error {
-	acquired, err := process.Lock(getLockPath())
+	acquired, err := runtime.Lock(getLockPath())
 	if err != nil {
 		return fmt.Errorf("failed to create lock file %q: %w", getLockPath(), err)
 	}
@@ -84,7 +84,7 @@ func main() {
 					return fmt.Errorf("error creating memory profiling file %q: %w", memProfileFileName, err)
 				}
 
-				runtime.MemProfileRate = memProfileRate
+				goruntime.MemProfileRate = memProfileRate
 			}
 
 			// trace program execution
@@ -102,7 +102,7 @@ func main() {
 			return nil
 		},
 		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
-			_ = process.Unlock(getLockPath())
+			_ = runtime.Unlock(getLockPath())
 			if cpuProfile {
 				pprof.StopCPUProfile()
 			}

--- a/pkg/agent/protocol/protocol_test.go
+++ b/pkg/agent/protocol/protocol_test.go
@@ -104,6 +104,7 @@ func Test_Validations(t *testing.T) {
 			t.Parallel()
 
 			_, err := NewDisruptor(
+				nil, // TODO: pass a fake executor
 				tc.config,
 				tc.proxy,
 			)

--- a/pkg/disruptors/pod_test.go
+++ b/pkg/disruptors/pod_test.go
@@ -6,14 +6,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/xk6-disruptor/pkg/runtime"
 	"github.com/grafana/xk6-disruptor/pkg/testutils/command"
-	"github.com/grafana/xk6-disruptor/pkg/utils/process"
 )
 
 type fakeAgentController struct {
 	namespace string
 	targets   []string
-	executor  *process.FakeExecutor
+	executor  *runtime.FakeExecutor
 }
 
 func (f *fakeAgentController) Targets(ctx context.Context) ([]string, error) {
@@ -168,7 +168,7 @@ func Test_PodHTTPFaultInjection(t *testing.T) {
 		t.Run(tc.title, func(t *testing.T) {
 			t.Parallel()
 
-			executor := process.NewFakeExecutor([]byte{}, tc.cmdError)
+			executor := runtime.NewFakeExecutor([]byte{}, tc.cmdError)
 
 			controller := &fakeAgentController{
 				namespace: tc.selector.Namespace,
@@ -325,7 +325,7 @@ func Test_PodGrpcPFaultInjection(t *testing.T) {
 		t.Run(tc.title, func(t *testing.T) {
 			t.Parallel()
 
-			executor := process.NewFakeExecutor([]byte{}, tc.cmdError)
+			executor := runtime.NewFakeExecutor([]byte{}, tc.cmdError)
 
 			controller := &fakeAgentController{
 				namespace: tc.selector.Namespace,

--- a/pkg/iptables/iptables.go
+++ b/pkg/iptables/iptables.go
@@ -44,8 +44,8 @@ type TrafficRedirectorConfig struct {
 	Executor runtime.Executor
 }
 
-// Creating instances passing a TrafficRedirectorConfig
-func newTrafficRedirectorWithConfig(
+// NewTrafficRedirectorWithConfig creates instances of traffic redirector using a TrafficRedirectorConfig
+func NewTrafficRedirectorWithConfig(
 	tr *TrafficRedirectionSpec,
 	config TrafficRedirectorConfig,
 ) (TrafficRedirector, error) {
@@ -76,7 +76,7 @@ func NewTrafficRedirector(tf *TrafficRedirectionSpec) (TrafficRedirector, error)
 	config := TrafficRedirectorConfig{
 		Executor: runtime.DefaultExecutor(),
 	}
-	return newTrafficRedirectorWithConfig(tf, config)
+	return NewTrafficRedirectorWithConfig(tf, config)
 }
 
 // delete iptables rules for redirection

--- a/pkg/iptables/iptables.go
+++ b/pkg/iptables/iptables.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/grafana/xk6-disruptor/pkg/utils/process"
+	"github.com/grafana/xk6-disruptor/pkg/runtime"
 )
 
 const redirectCommand = "%s PREROUTING -t nat -i %s -p tcp --dport %d -j REDIRECT --to-port %d"
@@ -36,12 +36,12 @@ type TrafficRedirector interface {
 // trafficRedirect defines an instance of a TrafficRedirector
 type redirector struct {
 	*TrafficRedirectionSpec
-	executor process.Executor
+	executor runtime.Executor
 }
 
 // TrafficRedirectorConfig defines the options for creating a TrafficRedirector
 type TrafficRedirectorConfig struct {
-	Executor process.Executor
+	Executor runtime.Executor
 }
 
 // Creating instances passing a TrafficRedirectorConfig
@@ -74,7 +74,7 @@ func newTrafficRedirectorWithConfig(
 // NewTrafficRedirector creates an instance of a TrafficRedirector with default configuration
 func NewTrafficRedirector(tf *TrafficRedirectionSpec) (TrafficRedirector, error) {
 	config := TrafficRedirectorConfig{
-		Executor: process.DefaultExecutor(),
+		Executor: runtime.DefaultExecutor(),
 	}
 	return newTrafficRedirectorWithConfig(tf, config)
 }

--- a/pkg/iptables/iptables_test.go
+++ b/pkg/iptables/iptables_test.go
@@ -178,7 +178,7 @@ func Test_Commands(t *testing.T) {
 			config := TrafficRedirectorConfig{
 				Executor: executor,
 			}
-			redirector, err := newTrafficRedirectorWithConfig(&tc.redirect, config)
+			redirector, err := NewTrafficRedirectorWithConfig(&tc.redirect, config)
 			if err != nil {
 				t.Errorf("failed creating traffic redirector with error %v", err)
 				return

--- a/pkg/iptables/iptables_test.go
+++ b/pkg/iptables/iptables_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/grafana/xk6-disruptor/pkg/utils/process"
+	"github.com/grafana/xk6-disruptor/pkg/runtime"
 )
 
 func Test_validateTrafficRedirect(t *testing.T) {
@@ -174,7 +174,7 @@ func Test_Commands(t *testing.T) {
 		t.Run(tc.title, func(t *testing.T) {
 			t.Parallel()
 
-			executor := process.NewFakeExecutor(tc.fakeOutput, tc.fakeError)
+			executor := runtime.NewFakeExecutor(tc.fakeOutput, tc.fakeError)
 			config := TrafficRedirectorConfig{
 				Executor: executor,
 			}

--- a/pkg/runtime/doc.go
+++ b/pkg/runtime/doc.go
@@ -1,0 +1,2 @@
+// Package runtime implements functions to interact with the execution runtime
+package runtime

--- a/pkg/runtime/executor.go
+++ b/pkg/runtime/executor.go
@@ -1,13 +1,10 @@
-// Package process offers abstractions for the execution of processes
-package process
+package runtime
 
 import (
 	"os/exec"
 )
 
 // Executor offers methods for running processes
-// It facilitates the testing of components that execute processes by providing
-// mock implementations.
 type Executor interface {
 	// Exec executes a process and waits for its completion, returning
 	// the combined stdout and stdout

--- a/pkg/runtime/executor_test.go
+++ b/pkg/runtime/executor_test.go
@@ -1,4 +1,4 @@
-package process
+package runtime
 
 import (
 	"testing"

--- a/pkg/runtime/fake.go
+++ b/pkg/runtime/fake.go
@@ -1,4 +1,4 @@
-package process
+package runtime
 
 import (
 	"strings"

--- a/pkg/runtime/fake_test.go
+++ b/pkg/runtime/fake_test.go
@@ -1,4 +1,4 @@
-package process
+package runtime
 
 import (
 	"errors"

--- a/pkg/runtime/lock_test.go
+++ b/pkg/runtime/lock_test.go
@@ -1,4 +1,4 @@
-package process
+package runtime
 
 import (
 	"fmt"

--- a/pkg/runtime/process.go
+++ b/pkg/runtime/process.go
@@ -1,0 +1,70 @@
+package runtime
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Process controls the process execution
+type Process interface {
+	// Name returns the name of the process
+	Name() string
+	// Lock tries to acquire an execution lock to prevent concurrent executions.
+	// Returns error if lock is already acquired by another process.
+	Lock() error
+	// Unlock releases the execution lock
+	Unlock() error
+	// Profiler returns the process profiler
+	Profiler(ProfilerConfig) (Profiler, error)
+}
+
+// process maintains the state of the process
+type process struct {
+	name string
+	lock string
+}
+
+func getLockDir() string {
+	// get runtime directory for user
+	lockDir := os.Getenv("XDG_RUNTIME_DIR")
+	if lockDir == "" {
+		lockDir = os.TempDir()
+	}
+
+	return lockDir
+}
+
+// DefaultProcess create a new Process for the currently running process.
+// When the process exits, the onExit function is executed.
+func DefaultProcess() Process {
+	name := filepath.Base(os.Args[0])
+	return &process{
+		name: name,
+		lock: filepath.Join(getLockDir(), name),
+	}
+}
+
+func (p *process) Name() string {
+	return p.name
+}
+
+func (p *process) Lock() error {
+	acquired, err := Lock(p.lock)
+	if err != nil {
+		return fmt.Errorf("failed to acquire lock file for process %q: %w", p.name, err)
+	}
+	if !acquired {
+		return fmt.Errorf("another process %q is already in execution", p.name)
+	}
+
+	return nil
+}
+
+func (p *process) Unlock() error {
+	return Unlock(p.lock)
+}
+
+func (p *process) Profiler(config ProfilerConfig) (Profiler, error) {
+	return NewProfiler(config)
+}

--- a/pkg/runtime/process.go
+++ b/pkg/runtime/process.go
@@ -15,8 +15,6 @@ type Process interface {
 	Lock() error
 	// Unlock releases the execution lock
 	Unlock() error
-	// Profiler returns the process profiler
-	Profiler(ProfilerConfig) (Profiler, error)
 }
 
 // process maintains the state of the process
@@ -67,8 +65,4 @@ func (p *process) Lock() error {
 
 func (p *process) Unlock() error {
 	return Unlock(p.lock)
-}
-
-func (p *process) Profiler(config ProfilerConfig) (Profiler, error) {
-	return NewProfiler(config)
 }

--- a/pkg/runtime/profiler.go
+++ b/pkg/runtime/profiler.go
@@ -1,0 +1,135 @@
+package runtime
+
+import (
+	"fmt"
+	"os"
+	goruntime "runtime"
+	"runtime/pprof"
+	"runtime/trace"
+)
+
+// ProfilerConfig defines the configuration of a Profiler
+type ProfilerConfig struct {
+	CPUProfile         bool
+	CPUProfileFileName string
+	MemProfile         bool
+	MemProfileRate     int
+	MemProfileFileName string
+	Trace              bool
+	TraceFileName      string
+}
+
+// Profiler defines the methods to control execution profiling
+type Profiler interface {
+	// Start initiates the tracing. If already active, has no effect
+	Start() error
+	// Stop terminates the tracing. If not started, has no effect
+	Stop() error
+}
+
+// profiler maintains the configuration state of the profiler
+type profiler struct {
+	ProfilerConfig
+	active         bool
+	cpuProfileFile *os.File
+	memProfileFile *os.File
+	traceFile      *os.File
+}
+
+// NewProfiler creates a Profiler instance
+func NewProfiler(config ProfilerConfig) (Profiler, error) {
+	if config.MemProfile {
+		if config.MemProfileRate < 0 {
+			return nil, fmt.Errorf("memory rate must be non-negative: %d", config.MemProfileRate)
+		}
+
+		if config.MemProfileFileName == "" {
+			return nil, fmt.Errorf("memory profile file name cannot be empty")
+		}
+	}
+
+	if config.CPUProfile {
+		if config.CPUProfileFileName == "" {
+			return nil, fmt.Errorf("CPU profile file name cannot be empty")
+		}
+	}
+
+	if config.Trace {
+		if config.TraceFileName == "" {
+			return nil, fmt.Errorf("trace output file name cannot be empty")
+		}
+	}
+
+	return &profiler{
+		ProfilerConfig: config,
+		active:         false,
+	}, nil
+}
+
+func (p *profiler) Start() error {
+	if p.active {
+		return nil
+	}
+
+	var err error
+	// cpu profiling
+	if p.CPUProfile {
+		p.cpuProfileFile, err = os.Create(p.CPUProfileFileName)
+		if err != nil {
+			return fmt.Errorf("error creating CPU profiling file %q: %w", p.CPUProfileFileName, err)
+		}
+
+		err = pprof.StartCPUProfile(p.cpuProfileFile)
+		if err != nil {
+			return fmt.Errorf("failed to start CPU profiling: %w", err)
+		}
+	}
+
+	// memory profiling
+	if p.MemProfile {
+		p.memProfileFile, err = os.Create(p.MemProfileFileName)
+		if err != nil {
+			return fmt.Errorf("error creating memory profiling file %q: %w", p.MemProfileFileName, err)
+		}
+
+		goruntime.MemProfileRate = p.MemProfileRate
+	}
+
+	// trace program execution
+	if p.Trace {
+		p.traceFile, err = os.Create(p.TraceFileName)
+		if err != nil {
+			return fmt.Errorf("failed to create trace output file %q: %w", p.TraceFileName, err)
+		}
+
+		if err := trace.Start(p.traceFile); err != nil {
+			return fmt.Errorf("failed to start trace: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func (p *profiler) Stop() error {
+	if !p.active {
+		return nil
+	}
+
+	if p.CPUProfile {
+		pprof.StopCPUProfile()
+	}
+
+	if p.MemProfile {
+		err := pprof.Lookup("heap").WriteTo(p.memProfileFile, 0)
+		if err != nil {
+			return fmt.Errorf("failed to write memory profile to file %q: %w", p.MemProfileFileName, err)
+		}
+	}
+
+	if p.Trace {
+		trace.Stop()
+		_ = p.traceFile.Close()
+	}
+
+	return nil
+}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -13,12 +13,15 @@ type Environment interface {
 	Executor() Executor
 	// Lock returns an interface for managing the process execution
 	Process() Process
+	// Profiler return an execution profiler
+	Profiler() Profiler
 }
 
 // environment keeps the state of the execution environment
 type environment struct {
 	executor Executor
 	process  Process
+	profiler Profiler
 }
 
 // returns a map with the environment variables
@@ -34,16 +37,21 @@ func getEnv() map[string]string {
 
 // DefaultEnvironment returns the default execution environment
 func DefaultEnvironment() Environment {
-	return environment{
+	return &environment{
 		executor: DefaultExecutor(),
 		process:  DefaultProcess(os.Args, getEnv()),
+		profiler: DefaultProfiler(),
 	}
 }
 
-func (e environment) Executor() Executor {
+func (e *environment) Executor() Executor {
 	return e.executor
 }
 
-func (e environment) Process() Process {
+func (e *environment) Process() Process {
 	return e.process
+}
+
+func (e *environment) Profiler() Profiler {
+	return e.profiler
 }

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1,6 +1,11 @@
 // Package runtime abstracts the execution environment of a process
 package runtime
 
+import (
+	"os"
+	"strings"
+)
+
 // Environment abstracts the execution environment of a process.
 // It allows introduction mocks for testing.
 type Environment interface {
@@ -16,11 +21,22 @@ type environment struct {
 	process  Process
 }
 
+// returns a map with the environment variables
+func getEnv() map[string]string {
+	env := map[string]string{}
+	for _, e := range os.Environ() {
+		k, v, _ := strings.Cut(e, "=")
+		env[k] = v
+	}
+
+	return env
+}
+
 // DefaultEnvironment returns the default execution environment
 func DefaultEnvironment() Environment {
 	return environment{
 		executor: DefaultExecutor(),
-		process:  DefaultProcess(),
+		process:  DefaultProcess(os.Args, getEnv()),
 	}
 }
 

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1,0 +1,33 @@
+// Package runtime abstracts the execution environment of a process
+package runtime
+
+// Environment abstracts the execution environment of a process.
+// It allows introduction mocks for testing.
+type Environment interface {
+	// Executor returns a process executor that abstracts os.Exec
+	Executor() Executor
+	// Lock returns an interface for managing the process execution
+	Process() Process
+}
+
+// environment keeps the state of the execution environment
+type environment struct {
+	executor Executor
+	process  Process
+}
+
+// DefaultEnvironment returns the default execution environment
+func DefaultEnvironment() Environment {
+	return environment{
+		executor: DefaultExecutor(),
+		process:  DefaultProcess(),
+	}
+}
+
+func (e environment) Executor() Executor {
+	return e.executor
+}
+
+func (e environment) Process() Process {
+	return e.process
+}


### PR DESCRIPTION
# Description

Introduce an abstraction for the runtime environment exposed by golang's `os` package, to facilitate testing. It is inspired by the [GlobalState](https://github.com/grafana/k6/blob/master/cmd/state/state.go) used in k6, but abstracts it into multiple interfaces.

The focus is on the agent's CLI command to facilitate testing changes such as [signal handling](#117 ) and the [cancellation of execution contexts](#174). 

Therefore it is out of scope to change the access to the `os` package in all packages. Follow-up PRs will address those. 

The current scope is to abstract:
 - [x] The execution of processes
 - [x] Control the current process (e.g. create execution lock, start/stop profiling) 
 - [x]  Access to environment variables 

Todo in follow-up PRs:
- [ ] Abstract signal handling
- [ ] [Provider logging interface](https://github.com/grafana/xk6-disruptor/issues/175)
- [ ] Abstract the access to file system
 
Out of scope:
- [ ] The [kubernetes package](pkg/kubernetes/config.go) still access the OS environment variables directly. 

Fixes #118 

# Checklist:

- [x] My code follows the coding style of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
