### PR TITLE
proxy/http: return upstream headers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.19
 
 require (
 	github.com/dop251/goja v0.0.0-20230128084908-78b980256d04
+	github.com/google/go-cmp v0.5.9
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.5.0
 	go.k6.io/k6 v0.42.1-0.20230130080633-582ec4d3940c
@@ -16,7 +17,6 @@ require (
 require (
 	github.com/bufbuild/protocompile v0.4.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
-	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/onsi/ginkgo v1.16.5 // indirect
 	google.golang.org/genproto v0.0.0-20230110181048-76db0878b65f // indirect
 )

--- a/pkg/agent/protocol/http/proxy.go
+++ b/pkg/agent/protocol/http/proxy.go
@@ -99,6 +99,7 @@ type httpHandler struct {
 
 func (h *httpHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	var statusCode int
+	headers := http.Header{}
 	body := io.NopCloser(strings.NewReader(h.disruption.ErrorBody))
 
 	excluded := contains(h.disruption.Excluded, req.URL.Path)
@@ -118,6 +119,7 @@ func (h *httpHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			return
 		}
 
+		headers = originServerResponse.Header
 		statusCode = originServerResponse.StatusCode
 		body = originServerResponse.Body
 
@@ -136,7 +138,11 @@ func (h *httpHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	}
 
 	// return response to the client
-	// TODO: return headers
+	for key, values := range headers {
+		for _, value := range values {
+			rw.Header().Add(key, value)
+		}
+	}
 	rw.WriteHeader(statusCode)
 
 	// ignore errors writing body, nothing to do.


### PR DESCRIPTION
# Description

This PR started as a quick fix returning upstream headers. During this quick patch I also realized there weren't any integration tests for the proxy, so I added one for this feature.

The added tests can be expanded to cover more cases as well.

Fixes: #182 

# Checklist:

- [x] My code follows the coding style of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works.   
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
