### PR TITLE
Use tmpfs for etcd in e2e test clusters

### DIFF
--- a/e2e/cluster/cluster_e2e_test.go
+++ b/e2e/cluster/cluster_e2e_test.go
@@ -41,6 +41,30 @@ func Test_DefaultConfig(t *testing.T) {
 	cluster.Delete()
 }
 
+func Test_UseEtcdRamDisk(t *testing.T) {
+	// create cluster with default configuration
+	config, err := cluster.NewConfig(
+		"e2e-etcdramdisk-cluster",
+		cluster.Options{
+			Wait:           time.Second * 60,
+			UseEtcdRAMDisk: true,
+		},
+	)
+	if err != nil {
+		t.Errorf("failed creating cluster configuration: %v", err)
+		return
+	}
+
+	cluster, err := config.Create()
+	if err != nil {
+		t.Errorf("failed to create cluster: %v", err)
+		return
+	}
+
+	// delete cluster
+	cluster.Delete()
+}
+
 func getKubernetesClient(kubeconfig string) (kubernetes.Interface, error) {
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
@@ -125,7 +149,6 @@ func Test_PreloadImages(t *testing.T) {
 		return
 	}
 }
-
 
 func Test_KubernetesVersion(t *testing.T) {
 	// create cluster with default configuration

--- a/pkg/testutils/cluster/cluster.go
+++ b/pkg/testutils/cluster/cluster.go
@@ -31,6 +31,14 @@ apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane`
 
+const etcdPatch = `
+kubeadmConfigPatches:
+- |
+  kind: ClusterConfiguration
+  etcd:
+    local:
+      dataDir: /tmp/etcd`
+
 const kindPortMapping = `
   - containerPort: %d
     hostPort: %d
@@ -62,6 +70,8 @@ type Options struct {
 	Version string
 	// Path to Kubeconfig
 	Kubeconfig string
+	// UseEtcdRAMDisk
+	UseEtcdRAMDisk bool
 }
 
 // Config contains the configuration for creating a cluster
@@ -115,6 +125,10 @@ func (c *Config) Render() (string, error) {
 
 	for i := 0; i < c.options.Workers; i++ {
 		fmt.Fprintf(&config, "\n- role: worker")
+	}
+
+	if c.options.UseEtcdRAMDisk {
+		fmt.Fprintf(&config, "\n%s", etcdPatch)
 	}
 
 	return config.String(), nil


### PR DESCRIPTION
# Description

Add configuration to the kind cluster for setting etcd storage path to a memory-mapped volume. 

Fixes #179 

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works.   
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make test`) and all tests pass.
- [x] I have run relevant e2e test locally (`make e2e-xxx` for `agent`, `disruptors`, `kubernetes` or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
