### PR TITLE
Pass context to commands

### DIFF
--- a/cmd/agent/commands/grpc.go
+++ b/cmd/agent/commands/grpc.go
@@ -57,7 +57,7 @@ func BuildGrpcCmd(env runtime.Environment) *cobra.Command {
 				return err
 			}
 
-			return disruptor.Apply(duration)
+			return disruptor.Apply(cmd.Context(), duration)
 		},
 	}
 	cmd.Flags().DurationVarP(&duration, "duration", "d", 0, "duration of the disruptions")

--- a/cmd/agent/commands/http.go
+++ b/cmd/agent/commands/http.go
@@ -57,7 +57,7 @@ func BuildHTTPCmd(env runtime.Environment) *cobra.Command {
 				return err
 			}
 
-			return disruptor.Apply(duration)
+			return disruptor.Apply(cmd.Context(), duration)
 		},
 	}
 	cmd.Flags().DurationVarP(&duration, "duration", "d", 0, "duration of the disruptions")

--- a/cmd/agent/commands/root.go
+++ b/cmd/agent/commands/root.go
@@ -17,7 +17,7 @@ type RootCommand struct {
 
 // BuildRootCmd builds the root command for the agent with all the persistent flags.
 // It also initializes/terminates the profiling if requested.
-func BuildRootCmd(env runtime.Environment) *RootCommand {
+func BuildRootCmd(env runtime.Environment, subcommands []*cobra.Command) *RootCommand {
 	rootCmd := &cobra.Command{
 		Use:   "xk6-disruptor-agent",
 		Short: "Inject disruptions in a system",
@@ -42,8 +42,9 @@ func BuildRootCmd(env runtime.Environment) *RootCommand {
 	rootCmd.PersistentFlags().StringVar(&profilerConfig.TraceFileName, "trace-file", "trace.out", "tracing output file")
 
 	// Add subcommands
-	rootCmd.AddCommand(BuildHTTPCmd(env))
-	rootCmd.AddCommand(BuildGrpcCmd(env))
+	for _, sc := range subcommands {
+		rootCmd.AddCommand(sc)
+	}
 
 	return &RootCommand{
 		env:            env,

--- a/cmd/agent/commands/root.go
+++ b/cmd/agent/commands/root.go
@@ -1,6 +1,7 @@
 package commands
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/grafana/xk6-disruptor/pkg/runtime"
@@ -50,7 +51,7 @@ func BuildRootCmd(env runtime.Environment) *RootCommand {
 }
 
 // Do executes the RootCommand
-func (r *RootCommand) Do() error {
+func (r *RootCommand) Do(ctx context.Context) error {
 	if err := r.env.Process().Lock(); err != nil {
 		return fmt.Errorf("could not acquire process lock %w", err)
 	}
@@ -66,6 +67,13 @@ func (r *RootCommand) Do() error {
 	defer func() {
 		_ = profiler.Close()
 	}()
+
+	// set context for command
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// pass context to subcommands
+	r.cmd.SetContext(ctx)
 
 	return r.cmd.Execute()
 }

--- a/cmd/agent/commands/root.go
+++ b/cmd/agent/commands/root.go
@@ -27,6 +27,8 @@ func BuildRootCmd(env runtime.Environment) *RootCommand {
 		SilenceErrors: true,
 	}
 
+	rootCmd.SetArgs(env.Args()[1:])
+
 	profilerConfig := runtime.ProfilerConfig{}
 
 	rootCmd.PersistentFlags().BoolVar(&profilerConfig.CPUProfile, "cpu-profile", false, "profile agent execution")

--- a/cmd/agent/commands/root.go
+++ b/cmd/agent/commands/root.go
@@ -2,51 +2,31 @@ package commands
 
 import (
 	"fmt"
-	"io"
 
 	"github.com/grafana/xk6-disruptor/pkg/runtime"
 	"github.com/spf13/cobra"
 )
 
+// RootCommand maintains the state required for executing an agent command
+type RootCommand struct {
+	env            runtime.Environment
+	cmd            *cobra.Command
+	profilerConfig runtime.ProfilerConfig
+}
+
 // BuildRootCmd builds the root command for the agent with all the persistent flags.
 // It also initializes/terminates the profiling if requested.
-func BuildRootCmd(env runtime.Environment) *cobra.Command {
-	profilerConfig := runtime.ProfilerConfig{}
-	var profiler io.Closer
-
+func BuildRootCmd(env runtime.Environment) *RootCommand {
 	rootCmd := &cobra.Command{
 		Use:   "xk6-disruptor-agent",
 		Short: "Inject disruptions in a system",
 		Long: "A command for injecting disruptions in a target system.\n" +
 			"It can run as stand-alone process or in a container",
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			err := env.Process().Lock()
-			if err != nil {
-				return err
-			}
-
-			profiler, err = env.Profiler().Start(profilerConfig)
-			if err != nil {
-				return fmt.Errorf("could not create profiler %w", err)
-			}
-
-			return nil
-		},
-		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {
-			defer func() {
-				_ = env.Process().Unlock()
-			}()
-
-			err := profiler.Close()
-			if err != nil {
-				return fmt.Errorf("could not stop profiler %w", err)
-			}
-
-			return nil
-		},
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
+
+	profilerConfig := runtime.ProfilerConfig{}
 
 	rootCmd.PersistentFlags().BoolVar(&profilerConfig.CPUProfile, "cpu-profile", false, "profile agent execution")
 	rootCmd.PersistentFlags().StringVar(&profilerConfig.CPUProfileFileName, "cpu-profile-file", "cpu.pprof",
@@ -58,5 +38,34 @@ func BuildRootCmd(env runtime.Environment) *cobra.Command {
 	rootCmd.PersistentFlags().BoolVar(&profilerConfig.Trace, "trace", false, "trace agent execution")
 	rootCmd.PersistentFlags().StringVar(&profilerConfig.TraceFileName, "trace-file", "trace.out", "tracing output file")
 
-	return rootCmd
+	// Add subcommands
+	rootCmd.AddCommand(BuildHTTPCmd(env))
+	rootCmd.AddCommand(BuildGrpcCmd(env))
+
+	return &RootCommand{
+		env:            env,
+		cmd:            rootCmd,
+		profilerConfig: profilerConfig,
+	}
+}
+
+// Do executes the RootCommand
+func (r *RootCommand) Do() error {
+	if err := r.env.Process().Lock(); err != nil {
+		return fmt.Errorf("could not acquire process lock %w", err)
+	}
+	defer func() {
+		_ = r.env.Process().Unlock()
+	}()
+
+	profiler, err := r.env.Profiler().Start(r.profilerConfig)
+	if err != nil {
+		return fmt.Errorf("could not create profiler %w", err)
+	}
+
+	defer func() {
+		_ = profiler.Close()
+	}()
+
+	return r.cmd.Execute()
 }

--- a/cmd/agent/commands/root_test.go
+++ b/cmd/agent/commands/root_test.go
@@ -1,0 +1,79 @@
+package commands
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/grafana/xk6-disruptor/pkg/runtime"
+	"github.com/spf13/cobra"
+)
+
+// BuildNoopCmd returns a corba.Command that returns after the given delay
+func BuildNoopCmd() *cobra.Command {
+	var delay time.Duration
+
+	cmd := &cobra.Command{
+		Use: "noop",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			time.Sleep(delay)
+			return nil
+		},
+	}
+
+	cmd.Flags().DurationVarP(&delay, "delay", "d", 0, "delay of the disruptions")
+	return cmd
+}
+
+func Test_CancelContext(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		title   string
+		args    []string
+		vars    map[string]string
+		subcmds []*cobra.Command
+		err     error
+	}{
+		{
+			title: "Command is not canceled",
+			args:  []string{"xk6-disruptor", "noop", "-d", "0s"},
+			vars:  map[string]string{},
+			subcmds: []*cobra.Command{
+				BuildNoopCmd(),
+			},
+			err: nil,
+		},
+		{
+			title: "Command is canceled",
+			args:  []string{"xk6-disruptor", "noop", "-d", "5s"},
+			vars:  map[string]string{},
+			subcmds: []*cobra.Command{
+				BuildNoopCmd(),
+			},
+			err: context.Canceled,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.title, func(t *testing.T) {
+			t.Parallel()
+			env := runtime.NewFakeRuntime(tc.args, tc.vars)
+
+			rootCmd := BuildRootCmd(env, tc.subcmds)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			go func() {
+				time.Sleep(1 * time.Second)
+				cancel()
+			}()
+
+			err := rootCmd.Do(ctx)
+			if !errors.Is(err, tc.err) {
+				t.Errorf("expected %v got %v", err, tc.err)
+			}
+		})
+	}
+}

--- a/cmd/agent/commands/root_test.go
+++ b/cmd/agent/commands/root_test.go
@@ -72,7 +72,7 @@ func Test_CancelContext(t *testing.T) {
 
 			err := rootCmd.Do(ctx)
 			if !errors.Is(err, tc.err) {
-				t.Errorf("expected %v got %v", err, tc.err)
+				t.Errorf("expected %v got %v", tc.err, err)
 			}
 		})
 	}

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -11,12 +11,7 @@ import (
 
 func main() {
 	env := runtime.DefaultEnvironment()
-	rootCmd := commands.BuildRootCmd(env)
-
-	rootCmd.AddCommand(commands.BuildHTTPCmd(env))
-	rootCmd.AddCommand(commands.BuildGrpcCmd(env))
-
-	if err := rootCmd.Execute(); err != nil {
+	if err := commands.BuildRootCmd(env).Do(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -11,7 +12,8 @@ import (
 
 func main() {
 	env := runtime.DefaultEnvironment()
-	if err := commands.BuildRootCmd(env).Do(); err != nil {
+	ctx := context.Background()
+	if err := commands.BuildRootCmd(env).Do(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -8,12 +8,20 @@ import (
 
 	"github.com/grafana/xk6-disruptor/cmd/agent/commands"
 	"github.com/grafana/xk6-disruptor/pkg/runtime"
+	"github.com/spf13/cobra"
 )
 
 func main() {
 	env := runtime.DefaultEnvironment()
 	ctx := context.Background()
-	if err := commands.BuildRootCmd(env).Do(ctx); err != nil {
+
+	subcommands := []*cobra.Command{
+		commands.BuildHTTPCmd(env),
+		commands.BuildGrpcCmd(env),
+	}
+
+	rootCmd := commands.BuildRootCmd(env, subcommands)
+	if err := rootCmd.Do(ctx); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -15,6 +15,10 @@ type Environment interface {
 	Process() Process
 	// Profiler return an execution profiler
 	Profiler() Profiler
+	// Vars returns the environment variables
+	Vars() map[string]string
+	// Args returns the arguments passed to the process
+	Args() []string
 }
 
 // environment keeps the state of the execution environment
@@ -22,6 +26,8 @@ type environment struct {
 	executor Executor
 	process  Process
 	profiler Profiler
+	vars     map[string]string
+	args     []string
 }
 
 // returns a map with the environment variables
@@ -37,10 +43,14 @@ func getEnv() map[string]string {
 
 // DefaultEnvironment returns the default execution environment
 func DefaultEnvironment() Environment {
+	args := os.Args
+	vars := getEnv()
 	return &environment{
 		executor: DefaultExecutor(),
-		process:  DefaultProcess(os.Args, getEnv()),
+		process:  DefaultProcess(args, vars),
 		profiler: DefaultProfiler(),
+		vars:     vars,
+		args:     args,
 	}
 }
 
@@ -54,4 +64,12 @@ func (e *environment) Process() Process {
 
 func (e *environment) Profiler() Profiler {
 	return e.profiler
+}
+
+func (e *environment) Vars() map[string]string {
+	return e.vars
+}
+
+func (e *environment) Args() []string {
+	return e.args
 }

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -11,7 +11,7 @@ import (
 type Environment interface {
 	// Executor returns a process executor that abstracts os.Exec
 	Executor() Executor
-	// Lock returns an interface for managing the process execution
+	// Process returns an interface for managing the process execution
 	Process() Process
 	// Profiler return an execution profiler
 	Profiler() Profiler


### PR DESCRIPTION
# Description

Pass context along the execution of commands to allow canceling execution. Required for #117 

This change-set also significantly refactors the root command to facilitate testing using a fake implementation of the runtime environment introduced in #172.

Fixes #119 

# Checklist:

- [x] My code follows the coding style of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works.   
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
