### PR TITLE
Set up Renovate for dependency automation

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,35 @@
+{
+  "extends": [
+    ":disableDependencyDashboard",
+    ":semanticCommitsDisabled"
+  ],
+  "gomod": {}, // Upgrade go dependencies.
+  "github-actions": {}, // Upgrade GitHub actions.
+  // Renovate evaluates all packageRules and does not stop after the first match.
+  // Rules that appear later in this list override earlier rules.
+  "packageRules": [
+    // Group all Go dependencies in the same PR.
+    {
+      "matchManagers": ["gomod"],
+      "groupName": "go dependencies"
+    },
+    // Separate all kubernetes dependencies to a different PR.
+    {
+      "matchManagers": ["gomod"],
+      "matchPackagePrefixes": ["k8s.io/"],
+      "groupName": "go k8s libraries"
+    },
+    // Separate k6 dependencies to a different PR.
+    {
+      "matchManagers": ["gomod"],
+      "matchPackagePrefixes": ["go.k6.io/"],
+      "groupName": "k6 core"
+    },
+    // Group all core GitHub actions updates in the same PR.
+    {
+      "matchManagers": ["github-actions"],
+      "matchPackagePrefixes": ["actions/"],
+      "groupName": "core github actions"
+    }
+  ]
+}


### PR DESCRIPTION
# Description

This PR adds [renovate](https://github.com/apps/renovate) config to the disruptor repo, to automate creation of PRs upgrading the multiple dependencies we have, both for Go and otherwise.

It is currently configured to create PRs for new versions of:
- Go modules
- Docker base images (i.e. Alpine)
- Github actions

A preview on how this looks like can be found on my fork: https://github.com/roobre/xk6-disruptor/pulls

Fixes #181
