### PR TITLE
Add upstream host parameter to agent

### DIFF
--- a/cmd/agent/commands/grpc.go
+++ b/cmd/agent/commands/grpc.go
@@ -20,7 +20,7 @@ func BuildGrpcCmd(env runtime.Environment, config *agent.Config) *cobra.Command 
 	var port uint
 	var target uint
 	var iface string
-	upstreamHost := "localhost"
+	var upstreamHost string
 	transparent := true
 
 	//nolint: dupl
@@ -87,6 +87,8 @@ func BuildGrpcCmd(env runtime.Environment, config *agent.Config) *cobra.Command 
 	cmd.Flags().StringSliceVarP(&disruption.Excluded, "exclude", "x", []string{}, "comma-separated list of grpc services"+
 		" to be excluded from disruption")
 	cmd.Flags().BoolVar(&transparent, "transparent", true, "run as transparent proxy")
+	cmd.Flags().StringVar(&upstreamHost, "upstream-host", "localhost",
+		"upstream host to redirect traffic to")
 
 	return cmd
 }

--- a/cmd/agent/commands/http.go
+++ b/cmd/agent/commands/http.go
@@ -19,7 +19,7 @@ func BuildHTTPCmd(env runtime.Environment, config *agent.Config) *cobra.Command 
 	var port uint
 	var target uint
 	var iface string
-	upstreamHost := "localhost"
+	var upstreamHost string
 	transparent := true
 
 	//nolint: dupl
@@ -84,6 +84,8 @@ func BuildHTTPCmd(env runtime.Environment, config *agent.Config) *cobra.Command 
 	cmd.Flags().StringSliceVarP(&disruption.Excluded, "exclude", "x", []string{}, "comma-separated list of path(s)"+
 		" to be excluded from disruption")
 	cmd.Flags().BoolVar(&transparent, "transparent", true, "run as transparent proxy")
+	cmd.Flags().StringVar(&upstreamHost, "upstream-host", "localhost",
+		"upstream host to redirect traffic to")
 	cmd.Flags().StringVarP(&iface, "interface", "i", "eth0", "interface to disrupt")
 	cmd.Flags().UintVarP(&port, "port", "p", 8080, "port the proxy will listen to")
 	cmd.Flags().UintVarP(&target, "target", "t", 80, "port the proxy will redirect request to")


### PR DESCRIPTION
# Description

#169 introduced the possibility of running the agent as a (non-transparent) proxy and redirecting traffic to any upstream host. However, it forgot to add the upstream host a a parameter to the protocol injection commands. This PR fixes this.

# Checklist:

- [X] My code follows the coding style of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works.   
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
