### PR TITLE
Makefile: allow overriding image and agent_image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,17 @@
 work_dir = $(shell pwd)
 golangci_version = $(shell head -n 1 .golangci.yml | tr -d '\# ')
 arch = $(shell go env GOARCH)
+image ?= ghcr.io/grafana/xk6-disruptor:latest
+agent_image ?= ghcr.io/grafana/xk6-disruptor-agent:latest
 
 all: build
 
 agent-image: build-agent test
-	docker build --build-arg TARGETARCH=${arch} -t ghcr.io/grafana/xk6-disruptor-agent:latest images/agent
+	docker build --build-arg TARGETARCH=${arch} -t $(agent_image) images/agent
 
 disruptor-image:
 	./build-package.sh -o linux -a ${arch} -v latest -b image/dist/build build
-	docker build --build-arg TARGETARCH=${arch} -t ghcr.io/grafana/xk6-disruptor:latest images/disruptor
+	docker build --build-arg TARGETARCH=${arch} -t $(image) images/disruptor
 
 build: test
 	go install go.k6.io/xk6/cmd/xk6@latest


### PR DESCRIPTION
# Description

This simple PR allows to build the agent and disruptor images with non-standard names, like so:

```shell
agent_image=registry.local/xk6-disruptor-agent make agent-image
```

If empty, these variables fall back to the defaults they had before this PR.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make test`) and all tests pass.
- [ ] I have run relevant e2e test locally (`make e2e-xxx` for `agent`, `disruptors`, `kubernetes` or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
