### PR TITLE
Agent: wait for disruptor to finish cleanup after context cancel

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -62,13 +62,19 @@ func (r *Agent) ApplyDisruption(ctx context.Context, disruptor protocol.Disrupto
 
 	// set context for command
 	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
 
 	// execute action goroutine to prevent blocking
 	cc := make(chan error)
 	go func() {
 		cc <- disruptor.Apply(ctx, duration)
+		close(cc)
 	}()
+
+	defer func() {
+		<-cc
+	}()
+
+	defer cancel()
 
 	// wait for command completion or cancellation
 	select {


### PR DESCRIPTION
# Description

Before this PR, `ApplyDisruption` deferred a context `cancel()`, which triggered interruption and cleanup of `disruptor.Apply` running on a separate goroutine. However, `ApplyDisruption` did not wait for `disruptor.Apply` to finish before returing and eventually terminating the program, which may cause `disruptor.Apply` to not be fully executed.

This PR adds a deferred receive from the channel where `disruptor.Apply` sends its return value to ensure the main routine waits for it to terminate. To prevent a double-receive scenario, the goroutine running `disruptor.Apply` now closes the channel after sending the return value, making receives other than the first noop.

Lastly, the deferred context cancel have been moved last in the defer stack so it's the first one being executed.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make test`) and all tests pass.
- [ ] I have run relevant e2e test locally (`make e2e-xxx` for `agent`, `disruptors`, `kubernetes` or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
