### PR TITLE
WIP: Add and use a dedicated IP to communicate with upstream

### DIFF
--- a/cmd/agent/commands/grpc.go
+++ b/cmd/agent/commands/grpc.go
@@ -57,6 +57,9 @@ func BuildGrpcCmd(env runtime.Environment, config *agent.Config) *cobra.Command 
 				if err != nil {
 					return err
 				}
+
+				// Tell GRPC proxy to send requests from transparentAddress.
+				proxyConfig.LocalAddress = transparentAddress
 			} else {
 				redirector = protocol.NoopTrafficRedirector()
 			}

--- a/e2e/agent/agent_e2e_test.go
+++ b/e2e/agent/agent_e2e_test.go
@@ -30,10 +30,10 @@ var injectHTTP500 = []string{
 	"1.0",
 	"--error",
 	"500",
-	"--port",
-	"8080",
+	"--listen",
+	":8080",
 	"--target",
-	"80",
+	"localhost:80",
 }
 
 var injectGrpcInternal = []string{
@@ -47,10 +47,10 @@ var injectGrpcInternal = []string{
 	"14",
 	"--message",
 	"Internal error",
-	"--port",
-	"4000",
+	"--listen",
+	":4000",
 	"--target",
-	"9000",
+	"localhost:9000",
 	"-x",
 	// exclude reflection service otherwise the dynamic client will not work
 	"grpc.reflection.v1alpha.ServerReflection,grpc.reflection.v1.ServerReflection",
@@ -65,12 +65,11 @@ var injectUpstreamHTTP500 = []string{
 	"1.0",
 	"--error",
 	"500",
-	"--port",
-	"80",
+	"--listen",
+	":80",
 	"--target",
-	"80",
+	"httpbin.default.svc.cluster.local:80",
 	"--transparent=false",
-	"--upstream-host=httpbin.default.svc.cluster.local",
 }
 
 // deploy pod with [httpbin] and the xk6-disruptor as sidekick container
@@ -121,7 +120,6 @@ func buildGrpcbinPodWithDisruptorAgent(cmd []string) *corev1.Pod {
 		Build()
 }
 
-
 // deploy pod with the xk6-disruptor
 func buildDisruptorAgentPod(cmd []string) *corev1.Pod {
 
@@ -141,7 +139,6 @@ func buildDisruptorAgentPod(cmd []string) *corev1.Pod {
 		WithContainer(*agent).
 		Build()
 }
-
 
 // builDisruptorService returns a Service definition that exposes httpbin pods
 func builDisruptorService() *corev1.Service {
@@ -290,7 +287,6 @@ func Test_Agent(t *testing.T) {
 			t.Errorf("unexpected error: %s: ", string(stderr))
 		}
 	})
-
 
 	t.Run("Non-transparent proxy to upstream service", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/agent/protocol/http/proxy.go
+++ b/pkg/agent/protocol/http/proxy.go
@@ -160,15 +160,10 @@ func (p *proxy) Start() error {
 		return err
 	}
 
-	client, err := httpClientUsingAddress(p.config.LocalAddress)
-	if err != nil {
-		return err
-	}
-
 	handler := &httpHandler{
 		upstreamURL: *upstreamURL,
 		disruption:  p.disruption,
-		client:      client,
+		client:      httpClientUsingAddress(p.config.LocalAddress),
 	}
 
 	p.srv = &http.Server{
@@ -202,7 +197,7 @@ func (p *proxy) Force() error {
 // httpClientUsingAddress returns an *http.Client configured to send requests from the specified IP address.
 // If an empty string is supplied, the returned client behaves like the default client and is not bound to any
 // particular address.
-func httpClientUsingAddress(localAddr string) (*http.Client, error) {
+func httpClientUsingAddress(localAddr string) *http.Client {
 	var tcpAddr *net.TCPAddr
 
 	if localAddr != "" {
@@ -239,5 +234,5 @@ func httpClientUsingAddress(localAddr string) (*http.Client, error) {
 			TLSHandshakeTimeout:   10 * time.Second,
 			ExpectContinueTimeout: 1 * time.Second,
 		},
-	}, nil
+	}
 }

--- a/pkg/disruptors/cmd_builders.go
+++ b/pkg/disruptors/cmd_builders.go
@@ -2,6 +2,7 @@ package disruptors
 
 import (
 	"fmt"
+	"net"
 	"time"
 
 	"github.com/grafana/xk6-disruptor/pkg/utils"
@@ -39,7 +40,7 @@ func buildGrpcFaultCmd(fault GrpcFault, duration time.Duration, options GrpcDisr
 	}
 
 	if fault.Port != 0 {
-		cmd = append(cmd, "-t", fmt.Sprint(fault.Port))
+		cmd = append(cmd, "--target", net.JoinHostPort("localhost", fmt.Sprint(fault.Port)))
 	}
 
 	if len(fault.Exclude) > 0 {
@@ -47,11 +48,7 @@ func buildGrpcFaultCmd(fault GrpcFault, duration time.Duration, options GrpcDisr
 	}
 
 	if options.ProxyPort != 0 {
-		cmd = append(cmd, "-p", fmt.Sprint(options.ProxyPort))
-	}
-
-	if options.Iface != "" {
-		cmd = append(cmd, "-i", options.Iface)
+		cmd = append(cmd, "--listen", fmt.Sprintf(":%d", options.ProxyPort))
 	}
 
 	return cmd
@@ -89,7 +86,7 @@ func buildHTTPFaultCmd(fault HTTPFault, duration time.Duration, options HTTPDisr
 	}
 
 	if fault.Port != 0 {
-		cmd = append(cmd, "-t", fmt.Sprint(fault.Port))
+		cmd = append(cmd, "--target", net.JoinHostPort("localhost", fmt.Sprint(fault.Port)))
 	}
 
 	if len(fault.Exclude) > 0 {
@@ -97,11 +94,7 @@ func buildHTTPFaultCmd(fault HTTPFault, duration time.Duration, options HTTPDisr
 	}
 
 	if options.ProxyPort != 0 {
-		cmd = append(cmd, "-p", fmt.Sprint(options.ProxyPort))
-	}
-
-	if options.Iface != "" {
-		cmd = append(cmd, "-i", options.Iface)
+		cmd = append(cmd, "--listen", fmt.Sprintf(":%d", options.ProxyPort))
 	}
 
 	return cmd

--- a/pkg/iproute/iproute.go
+++ b/pkg/iproute/iproute.go
@@ -1,0 +1,40 @@
+// Package iproute houses the IPRoute object, which can be used to add and and remove IP addresses from interfaces
+// by wrapping the ip(8) command.
+package iproute
+
+import (
+	"fmt"
+
+	"github.com/grafana/xk6-disruptor/pkg/runtime"
+)
+
+// IPRoute implements adding and removing IP addresses from interfaces.
+type IPRoute struct {
+	exec runtime.Executor
+}
+
+// New returns a new IPRoute.
+func New(executor runtime.Executor) IPRoute {
+	return IPRoute{
+		exec: executor,
+	}
+}
+
+// Add adds the given IP address, in CIDR notation, to the given device.
+func (ip IPRoute) Add(addrCidr, dev string) error {
+	return ip.addr("add", addrCidr, dev)
+}
+
+// Delete removes the given IP address, in CIDR notation, from the given device.
+func (ip IPRoute) Delete(addrCidr, dev string) error {
+	return ip.addr("del", addrCidr, dev)
+}
+
+func (ip IPRoute) addr(operation, addrCidr, dev string) error {
+	out, err := ip.exec.Exec("ip", "addr", operation, addrCidr, "dev", dev)
+	if err != nil {
+		return fmt.Errorf("running ip %s operation: %q: %w", operation, string(out), err)
+	}
+
+	return nil
+}

--- a/pkg/iproute/iproute_test.go
+++ b/pkg/iproute/iproute_test.go
@@ -1,0 +1,64 @@
+package iproute_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/grafana/xk6-disruptor/pkg/iproute"
+	"github.com/grafana/xk6-disruptor/pkg/runtime"
+)
+
+func Test_IPRoute(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name        string
+		run         func(ip iproute.IPRoute) error
+		expectedCmd []string
+	}{
+		{
+			name: "Adds an IP address",
+			run: func(ip iproute.IPRoute) error {
+				return ip.Add("10.0.0.1/24", "eth0")
+			},
+			expectedCmd: []string{"ip addr add 10.0.0.1/24 dev eth0"},
+		},
+		{
+			name: "Removes an IP address",
+			run: func(ip iproute.IPRoute) error {
+				return ip.Delete("10.0.0.1/24", "eth0")
+			},
+			expectedCmd: []string{"ip addr del 10.0.0.1/24 dev eth0"},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			fakeExec := runtime.NewFakeExecutor(nil, nil)
+			ip := iproute.New(fakeExec)
+			err := tc.run(ip)
+			if err != nil {
+				t.Fatalf("returned error: %v", err)
+			}
+
+			if diff := cmp.Diff(tc.expectedCmd, fakeExec.CmdHistory()); diff != "" {
+				t.Errorf("commands ran do not match expectations:\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_IPRoutePropagatesErrors(t *testing.T) {
+	t.Parallel()
+
+	expectedErr := errors.New("propagated errors")
+
+	fakeExec := runtime.NewFakeExecutor([]byte("propagated error"), expectedErr)
+	ip := iproute.New(fakeExec)
+	err := ip.Add("something", "something")
+	if !errors.Is(err, expectedErr) {
+		t.Fatalf("returned error %q, expected %q", err, expectedErr)
+	}
+}

--- a/pkg/iptables/iptables.go
+++ b/pkg/iptables/iptables.go
@@ -37,7 +37,6 @@ var redirectChains = []string{"OUTPUT", "PREROUTING"}
 // forcing clients to re-establish connections.
 const resetCommand = "%s INPUT " + // For traffic traversing the INPUT chain
 	"! -s %s/32 " + // Not coming from the proxy address
-	"! -d %s/32 " + // Not directed to the proxy address
 	"-p tcp --dport %s " + // Directed to the upstream application's port
 	"-m state --state ESTABLISHED " + // That are already ESTABLISHED, i.e. not before they are redirected
 	"-j REJECT --reject-with tcp-reset" // Reject it
@@ -145,7 +144,6 @@ func (tr *redirector) execResetCmd(action string) error {
 	cmd := fmt.Sprintf(
 		resetCommand,
 		action,
-		tr.LocalAddress,
 		tr.LocalAddress,
 		tr.TargetPort,
 	)

--- a/pkg/iptables/iptables_test.go
+++ b/pkg/iptables/iptables_test.go
@@ -104,7 +104,7 @@ func Test_Commands(t *testing.T) {
 				"ip addr add 127.120.107.6/32 dev lo",
 				"iptables -A OUTPUT -t nat -p tcp --dport 80 ! -s 127.120.107.6/32 -j REDIRECT --to-port 8080",
 				"iptables -A PREROUTING -t nat -p tcp --dport 80 ! -s 127.120.107.6/32 -j REDIRECT --to-port 8080",
-				"iptables -A INPUT ! -s 127.120.107.6/32 ! -d 127.120.107.6/32 -p tcp --dport 80 -m state --state ESTABLISHED -j REJECT --reject-with tcp-reset",
+				"iptables -A INPUT ! -s 127.120.107.6/32 -p tcp --dport 80 -m state --state ESTABLISHED -j REJECT --reject-with tcp-reset",
 			},
 			expectError: false,
 			fakeError:   nil,
@@ -124,7 +124,7 @@ func Test_Commands(t *testing.T) {
 			expectedCmds: []string{
 				"iptables -D OUTPUT -t nat -p tcp --dport 80 ! -s 127.120.107.6/32 -j REDIRECT --to-port 8080",
 				"iptables -D PREROUTING -t nat -p tcp --dport 80 ! -s 127.120.107.6/32 -j REDIRECT --to-port 8080",
-				"iptables -D INPUT ! -s 127.120.107.6/32 ! -d 127.120.107.6/32 -p tcp --dport 80 -m state --state ESTABLISHED -j REJECT --reject-with tcp-reset",
+				"iptables -D INPUT ! -s 127.120.107.6/32 -p tcp --dport 80 -m state --state ESTABLISHED -j REJECT --reject-with tcp-reset",
 				"ip addr del 127.120.107.6/32 dev lo",
 			},
 			expectError: false,


### PR DESCRIPTION
# Description

Currently, the disruptor does not support disrupting local traffic, such as that generated through `kubectl port-forward`. The main motivation for this is that, if we redirected traffic from `localhost` to `upstream` to the proxy, the traffic generated by the proxy itself would be re-redirected back to the proxy, causing an infinite loop of redirections.

To solve this, this PR allows the disruptor to create a local IP which is then used by the proxy to communicate with upstream.
This local IP is excluded from the redirection rule, breaking the aforementioned loop. Additionally, two separate rules are required to intercept local and non-local traffic, merely because it flow through different netfilter chains.

This PR also changes some CLI flags to make them more consistent with how they are propagated downstream. Properties of the exposed JS API have been made compatible with the new flags, but we could revise those if we wanted to.

Fixes https://github.com/grafana/xk6-disruptor/issues/214

~Includes commits from #225 and #226~

- [x] Basic, manually-tested implementation
- [x] Send HTTP traffic from the local IP
- [ ] Send GRPC traffic from the local IP
- [x] Run E2E tests

### Observations

I originally intended to, with this approach, also make the proxy listen only on this local-only IP. This, however, is not possible. The main reason for that is that the linux kernel does not allow to redirect traffic from external interfaces to local-only IP addresses.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make test`) and all tests pass.
- [x] I have run relevant e2e test locally (`make e2e-xxx` for `agent`, `disruptors`, `kubernetes` or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
