### PR TITLE
Allow interception of port-forwarded traffic by making the proxy target the pod IP

### DIFF
--- a/cmd/agent/commands/http.go
+++ b/cmd/agent/commands/http.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"net"
 	"time"
 
 	"github.com/grafana/xk6-disruptor/pkg/agent"
@@ -13,16 +14,16 @@ import (
 )
 
 // BuildHTTPCmd returns a cobra command with the specification of the http command
+//
+//nolint:funlen
 func BuildHTTPCmd(env runtime.Environment, config *agent.Config) *cobra.Command {
 	disruption := http.Disruption{}
 	var duration time.Duration
 	var port uint
-	var target uint
-	var iface string
 	var upstreamHost string
+	var targetPort uint
 	transparent := true
 
-	//nolint: dupl
 	cmd := &cobra.Command{
 		Use:   "http",
 		Short: "http disruptor",
@@ -30,11 +31,18 @@ func BuildHTTPCmd(env runtime.Environment, config *agent.Config) *cobra.Command 
 			" When running as a transparent proxy requires NET_ADMIM capabilities for setting" +
 			" iptable rules.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if target == 0 {
+			if targetPort == 0 {
 				return fmt.Errorf("target port for fault injection is required")
 			}
-			listenAddress := fmt.Sprintf(":%d", port)
-			upstreamAddress := fmt.Sprintf("http://%s:%d", upstreamHost, target)
+
+			if transparent && (upstreamHost == "localhost" || upstreamHost == "127.0.0.1") {
+				// When running in transparent mode, the Redirector will also redirect traffic directed to 127.0.0.1 to
+				// the proxy. Using 127.0.0.1 as the proxy upstream would cause a redirection loop.
+				return fmt.Errorf("upstream host cannot be localhost when running in transparent mode")
+			}
+
+			listenAddress := net.JoinHostPort("", fmt.Sprint(port))
+			upstreamAddress := "http://" + net.JoinHostPort(upstreamHost, fmt.Sprint(targetPort))
 
 			proxyConfig := http.ProxyConfig{
 				ListenAddress:   listenAddress,
@@ -50,9 +58,8 @@ func BuildHTTPCmd(env runtime.Environment, config *agent.Config) *cobra.Command 
 			var redirector protocol.TrafficRedirector
 			if transparent {
 				tr := &iptables.TrafficRedirectionSpec{
-					Iface:           iface,
-					DestinationPort: target,
-					RedirectPort:    port,
+					DestinationPort: targetPort, // Redirect traffic from the application (target) port...
+					RedirectPort:    port,       // to the proxy port.
 				}
 
 				redirector, err = iptables.NewTrafficRedirector(tr, env.Executor())
@@ -89,9 +96,8 @@ func BuildHTTPCmd(env runtime.Environment, config *agent.Config) *cobra.Command 
 	cmd.Flags().BoolVar(&transparent, "transparent", true, "run as transparent proxy")
 	cmd.Flags().StringVar(&upstreamHost, "upstream-host", "localhost",
 		"upstream host to redirect traffic to")
-	cmd.Flags().StringVarP(&iface, "interface", "i", "eth0", "interface to disrupt")
-	cmd.Flags().UintVarP(&port, "port", "p", 8000, "port the proxy will listen to")
-	cmd.Flags().UintVarP(&target, "target", "t", 0, "port the proxy will redirect request to")
+	cmd.Flags().UintVarP(&port, "port", "p", 8080, "port the proxy will listen to")
+	cmd.Flags().UintVarP(&targetPort, "target", "t", 0, "port the proxy will redirect request to")
 
 	return cmd
 }

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -213,7 +213,6 @@ func Test_JsPodDisruptor(t *testing.T) {
 
 			const faultOpts = {
 				proxyPort: 8080,
-				iface: "eth0"
 			}
 
 			d.injectHTTPFaults(fault, "1s", faultOpts)
@@ -298,7 +297,6 @@ func Test_JsPodDisruptor(t *testing.T) {
 
 			const faultOpts = {
 				proxyPort: 4000,
-				iface: "eth0"
 			}
 
 			d.injectGrpcFaults(fault, "1s", faultOpts)
@@ -337,7 +335,6 @@ func Test_JsPodDisruptor(t *testing.T) {
 
 			const faultOpts = {
 				proxyPort: 4000,
-				iface: "eth0"
 			}
 
 			d.injectGrpcFaults(fault)
@@ -359,7 +356,6 @@ func Test_JsPodDisruptor(t *testing.T) {
 
 			const faultOpts = {
 				proxyPort: 4000,
-				iface: "eth0"
 			}
 
 			d.injectGrpcFaults(fault, "1")    // missing duration unit

--- a/pkg/disruptors/cmd_builders.go
+++ b/pkg/disruptors/cmd_builders.go
@@ -51,8 +51,8 @@ func buildGrpcFaultCmd(fault GrpcFault, duration time.Duration, options GrpcDisr
 		cmd = append(cmd, "-p", fmt.Sprint(options.ProxyPort))
 	}
 
-	if options.Iface != "" {
-		cmd = append(cmd, "-i", options.Iface)
+	if options.TargetAddress != "" {
+		cmd = append(cmd, "--upstream-host", options.TargetAddress)
 	}
 
 	return cmd
@@ -101,8 +101,8 @@ func buildHTTPFaultCmd(fault HTTPFault, duration time.Duration, options HTTPDisr
 		cmd = append(cmd, "-p", fmt.Sprint(options.ProxyPort))
 	}
 
-	if options.Iface != "" {
-		cmd = append(cmd, "-i", options.Iface)
+	if options.TargetAddress != "" {
+		cmd = append(cmd, "--upstream-host", options.TargetAddress)
 	}
 
 	return cmd

--- a/pkg/disruptors/controller_test.go
+++ b/pkg/disruptors/controller_test.go
@@ -34,9 +34,11 @@ func Test_InjectAgent(t *testing.T) {
 			pods: []*corev1.Pod{
 				builders.NewPodBuilder("pod1").
 					WithNamespace("test-ns").
+					WithIP("192.0.2.6").
 					Build(),
 				builders.NewPodBuilder("pod2").
 					WithNamespace("test-ns").
+					WithIP("192.0.2.6").
 					Build(),
 			},
 			timeout:     -1,

--- a/pkg/disruptors/protocol.go
+++ b/pkg/disruptors/protocol.go
@@ -17,18 +17,20 @@ type ProtocolFaultInjector interface {
 
 // HTTPDisruptionOptions defines options for the injection of HTTP faults in a target pod
 type HTTPDisruptionOptions struct {
+	// IP address where the proxy will send requests.
+	// This is typically the pod IP. It must not be `localhost`.
+	TargetAddress string
 	// Port used by the agent for listening
 	ProxyPort uint `js:"proxyPort"`
-	// Network interface the agent will be listening traffic from
-	Iface string
 }
 
 // GrpcDisruptionOptions defines options for the injection of grpc faults in a target pod
 type GrpcDisruptionOptions struct {
+	// IP address where the proxy will send requests.
+	// This is typically the pod IP. It must not be `localhost`.
+	TargetAddress string
 	// Port used by the agent for listening
 	ProxyPort uint `js:"proxyPort"`
-	// Network interface the agent will be listening traffic from
-	Iface string
 }
 
 // HTTPFault specifies a fault to be injected in http requests

--- a/pkg/disruptors/service_test.go
+++ b/pkg/disruptors/service_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/grafana/xk6-disruptor/pkg/testutils/kubernetes/builders"
 )
 
+// TODO: Refactor tests so they include the generated command.
+// Currently we do not have tests covering command generation logic for ServiceDisruptor.
 func Test_NewServiceDisruptor(t *testing.T) {
 	t.Parallel()
 
@@ -49,7 +51,9 @@ func Test_NewServiceDisruptor(t *testing.T) {
 					WithNamespace("test-ns").
 					WithLabels(map[string]string{
 						"app": "test",
-					}).Build(),
+					}).
+					WithIP("192.0.2.6").
+					Build(),
 			},
 			endpoints: []*corev1.Endpoints{
 				builders.NewEndPointsBuilder("test-svc").

--- a/pkg/iptables/iptables.go
+++ b/pkg/iptables/iptables.go
@@ -4,6 +4,7 @@
 package iptables
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -11,17 +12,85 @@ import (
 	"github.com/grafana/xk6-disruptor/pkg/runtime"
 )
 
-const redirectCommand = "%s PREROUTING -t nat -i %s -p tcp --dport %d -j REDIRECT --to-port %d"
+// The four rules defined in the constants below achieve the following purposes:
+// - Redirect traffic to the target application through the proxy, excluding traffic from the proxy itself.
+// - Reset existing, non-redirected connections to the target application, except those of the proxy itself.
+// Excluding traffic from the proxy from the goals above is not entirely straightforward, mainly because the proxy,
+// just like `kubectl port-forward` and sidecars, connect _from_ the loopback address 127.0.0.1.
+//
+// To achieve this, we take advantage of the fact that the proxy knows the pod IP and connects to it, instead of to the
+// loopback address like sidecars and kubectl port-forward does. This allows us to distinguish the proxy traffic from
+// port-forwarded traffic, as while both traverse the `lo` interface, the former targets the pod IP while the latter
+// targets the loopback IP.
+//
 
-const resetCommand = "%s INPUT -i %s -p tcp --dport %d -m state --state ESTABLISHED -j REJECT --reject-with tcp-reset"
+// +-----------+---------------+------------------------+
+// | Interface | From/To       | What                   |
+// +-----------+---------------+------------------------+
+// | ! lo      | Anywhere      | Outside traffic        |
+// +-----------+---------------+------------------------+
+// | lo        | 127.0.0.0/8   | Port-forwarded traffic |
+// +-----------+---------------+------------------------+
+// | lo        | ! 127.0.0.0/8 | Proxy traffic          |
+// +-----------+---------------+------------------------+
+
+// redirectLocalRule is a netfilter rule that intercepts locally-originated traffic, such as that coming from sidecars
+// or `kubectl port-forward, directed to the application and redirects it to the proxy.
+// As per https://upload.wikimedia.org/wikipedia/commons/3/37/Netfilter-packet-flow.svg, locally originated traffic
+// traverses OUTPUT instead of PREROUTING.
+// Traffic created by the proxy itself to the application also traverses this chain, but is not redirected by this rule
+// as the proxy targets the pod IP and not the loopback address.
+const redirectLocalRule = "OUTPUT " + // For local traffic
+	"-t nat " + // Traversing the nat table
+	"-s 127.0.0.0/8 -d 127.0.0.1/32 " + // Coming from and directed to localhost, i.e. not the pod IP.
+	"-p tcp --dport %d " + // Sent to the upstream application's port
+	"-j REDIRECT --to-port %d" // Forward it to the proxy address
+
+// redirectExternalRule is a netfilter rule that intercepts external traffic directed to the application and redirects
+// it to the proxy.
+// Traffic created by the proxy itself to the application traverses is not redirected by this rule as it traverses the
+// OUTPUT chain, not PREROUTING.
+const redirectExternalRule = "PREROUTING " + // For remote traffic
+	"-t nat " + // Traversing the nat table
+	"! -i lo " + // Not coming form loopback. This is technically not needed, but doesn't hurt and helps readability.
+	"-p tcp --dport %d " + // Sent to the upstream application's port
+	"-j REDIRECT --to-port %d" // Forward it to the proxy address
+
+// resetLocalRule is a netfilter rule that resets established connections (i.e. that have not been redirected) coming
+// to and from the loopback address.
+// This rule matches connections from sidecars and `kubectl port-forward`.
+// Connections from the proxy itself do not match this rule, as although they flow through `lo`, they are directed to
+// the pod's external IP and not the loopback address.
+const resetLocalRule = "INPUT " + // For traffic traversing the INPUT chain
+	"-i lo " + // On the loopback interface
+	"-s 127.0.0.0/8 -d 127.0.0.1/32 " + // Coming from and directed to localhost
+	"-p tcp --dport %d " + // Directed to the upstream application's port
+	"-m state --state ESTABLISHED " + // That are already ESTABLISHED, i.e. not before they are redirected
+	"-j REJECT --reject-with tcp-reset" // Reject it
+
+// resetExternalRule is a netfilter rule that resets established connections (i.e. that have not been redirected) coming
+// from anywhere except the local IP.
+// This rule matches external connections to the pod's IP address.
+// Connections from the proxy itself do not match this rule, as they flow through the `lo` interface.
+const resetExternalRule = "INPUT " + // For traffic traversing the INPUT chain
+	"! -i lo " + // Not coming form loopback. This is technically not needed, but doesn't hurt and helps readability.
+	"-p tcp --dport %d " + // Directed to the upstream application's port
+	"-m state --state ESTABLISHED " + // That are already ESTABLISHED, i.e. not before they are redirected
+	"-j REJECT --reject-with tcp-reset" // Reject it
+
+// proxyResetRule is a netfilter rule that rejects traffic to the proxy.
+// This rule is set up after injection finishes to kill any leftover connection to the proxy.
+// TODO: Run some tests to check if this is really necessary, as the proxy may already be killing conns on termination.
+const resetProxyRule = "INPUT " + // Traffic flowing through the INPUT chain
+	"-p tcp --dport %d " + // Directed to the proxy port
+	"-j REJECT --reject-with tcp-reset" // Reject it
 
 // TrafficRedirectionSpec specifies the redirection of traffic to a destination
 type TrafficRedirectionSpec struct {
-	// Interface on which the traffic will be intercepted
-	Iface string
-	// Destination port of the traffic to be redirected
+	// DestinationPort is the original destination port where the upstream application listens.
 	DestinationPort uint
-	// Port the traffic will be redirected to
+	// RedirectPort is the port where the traffic should be redirected to.
+	// Typically, this would be where a transparent proxy is listening.
 	RedirectPort uint
 }
 
@@ -37,19 +106,15 @@ func NewTrafficRedirector(
 	executor runtime.Executor,
 ) (protocol.TrafficRedirector, error) {
 	if tr.DestinationPort == 0 || tr.RedirectPort == 0 {
-		return nil, fmt.Errorf("the DestinationPort and RedirectPort must be specified")
+		return nil, fmt.Errorf("DestinationPort and RedirectPort must be specified")
 	}
 
 	if tr.DestinationPort == tr.RedirectPort {
 		return nil, fmt.Errorf(
-			"the DestinationPort (%d) and RedirectPort (%d) must be different",
+			"DestinationPort (%d) and RedirectPort (%d) must be different",
 			tr.DestinationPort,
 			tr.RedirectPort,
 		)
-	}
-
-	if tr.Iface == "" {
-		return nil, fmt.Errorf("the Iface must be specified")
 	}
 
 	return &redirector{
@@ -58,81 +123,101 @@ func NewTrafficRedirector(
 	}, nil
 }
 
-// delete iptables rules for redirection
-func (tr *redirector) deleteRedirectRules() error {
-	return tr.execRedirectCmd("-D")
+func (tr *redirector) redirectRules() []string {
+	return []string{
+		fmt.Sprintf(
+			redirectLocalRule,
+			tr.DestinationPort,
+			tr.RedirectPort,
+		),
+		fmt.Sprintf(
+			redirectExternalRule,
+			tr.DestinationPort,
+			tr.RedirectPort,
+		),
+	}
 }
 
-// add iptables rules for redirection
-func (tr *redirector) addRedirectRules() error {
-	return tr.execRedirectCmd("-A")
+func (tr *redirector) resetRules() []string {
+	return []string{
+		fmt.Sprintf(
+			resetLocalRule,
+			tr.DestinationPort,
+		),
+		fmt.Sprintf(
+			resetExternalRule,
+			tr.DestinationPort,
+		),
+	}
 }
 
-// add iptables rules for reset connections to port
-func (tr *redirector) addResetRules(port uint) error {
-	return tr.execResetCmd("-A", port)
+func (tr *redirector) resetProxyRule() string {
+	return fmt.Sprintf(resetProxyRule, tr.RedirectPort)
 }
 
-// delete iptables rules for reset connections to port
-func (tr *redirector) deleteResetRules(port uint) error {
-	return tr.execResetCmd("-D", port)
-}
-
-// buildRedirectCmd builds a command for adding or removing a transparent proxy using iptables
-func (tr *redirector) execRedirectCmd(action string) error {
-	cmd := fmt.Sprintf(
-		redirectCommand,
-		action,
-		tr.Iface,
-		tr.DestinationPort,
-		tr.RedirectPort,
-	)
-
+// execIptables runs performs the specified action ("-A" or "-D") for the supplied rule.
+func (tr *redirector) execIptables(action string, rule string) error {
+	cmd := fmt.Sprintf("%s %s", action, rule)
 	out, err := tr.executor.Exec("iptables", strings.Split(cmd, " ")...)
 	if err != nil {
-		return fmt.Errorf("error executing iptables command: %w %s", err, string(out))
+		return fmt.Errorf("error executing iptables command %q: %w %s", cmd, err, string(out))
 	}
 
 	return nil
 }
 
-func (tr *redirector) execResetCmd(action string, port uint) error {
-	cmd := fmt.Sprintf(
-		resetCommand,
-		action,
-		tr.Iface,
-		port,
-	)
-
-	out, err := tr.executor.Exec("iptables", strings.Split(cmd, " ")...)
-	if err != nil {
-		return fmt.Errorf("error executing iptables command: %s", string(out))
-	}
-
-	return nil
-}
-
-// Starts applies the TrafficRedirect
+// Start applies the TrafficRedirect
 func (tr *redirector) Start() error {
-	// error is ignored as the rule may not exist
-	_ = tr.deleteResetRules(tr.RedirectPort)
-	if err := tr.addRedirectRules(); err != nil {
-		return err
+	// Remove reset rule for the proxy in case it exists from a previous run.
+	_ = tr.execIptables("-D", tr.resetProxyRule())
+
+	for _, rule := range tr.redirectRules() {
+		err := tr.execIptables("-A", rule)
+		if err != nil {
+			return err
+		}
 	}
-	return tr.addResetRules(tr.DestinationPort)
+
+	for _, rule := range tr.resetRules() {
+		err := tr.execIptables("-A", rule)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
-// Stops removes the TrafficRedirect
+// Stop stops the TrafficRedirect.
+// Stop will continue attempting to remove all the rules it deployed even if removing one fails.
+// TODO: The error returned does not wrap original errors.
 func (tr *redirector) Stop() error {
-	err := tr.deleteRedirectRules()
-	if err != nil {
-		return err
+	var errs []string
+
+	// TODO: Replace this homemade error aggregation with errors.Join when we upgrade from Go 1.19 to 1.20.
+	for _, rule := range tr.redirectRules() {
+		err := tr.execIptables("-D", rule)
+		if err != nil {
+			errs = append(errs, err.Error())
+		}
 	}
 
-	err = tr.addResetRules(tr.RedirectPort)
-	if err != nil {
-		return err
+	for _, rule := range tr.resetRules() {
+		err := tr.execIptables("-D", rule)
+		if err != nil {
+			errs = append(errs, err.Error())
+		}
 	}
 
-	return tr.deleteResetRules(tr.DestinationPort)
+	// Add rule to terminate any remaining traffic directed to the proxy.
+	err := tr.execIptables("-A", tr.resetProxyRule())
+	if err != nil {
+		errs = append(errs, err.Error())
+	}
+
+	if len(errs) > 0 {
+		return errors.New(strings.Join(errs, "; "))
+	}
+
+	return nil
 }

--- a/pkg/iptables/iptables_test.go
+++ b/pkg/iptables/iptables_test.go
@@ -2,9 +2,9 @@ package iptables
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/xk6-disruptor/pkg/agent/protocol"
 	"github.com/grafana/xk6-disruptor/pkg/runtime"
 )
@@ -20,37 +20,22 @@ func Test_validateTrafficRedirect(t *testing.T) {
 		{
 			title: "Valid redirect",
 			redirect: TrafficRedirectionSpec{
-				Iface:           "eth0",
 				DestinationPort: 80,
 				RedirectPort:    8080,
 			},
 			expectError: false,
 		},
 		{
-			title: "Ports not specified",
+			title: "Same target and proxy port",
 			redirect: TrafficRedirectionSpec{
-				Iface:           "eth0",
-				DestinationPort: 0,
-				RedirectPort:    0,
-			},
-			expectError: true,
-		},
-		{
-			title: "destination equals redirect port",
-			redirect: TrafficRedirectionSpec{
-				Iface:           "eth0",
-				DestinationPort: 80,
-				RedirectPort:    80,
-			},
-			expectError: true,
-		},
-		{
-			title: "Invalid iface",
-			redirect: TrafficRedirectionSpec{
-				Iface:           "",
-				DestinationPort: 80,
+				DestinationPort: 8080,
 				RedirectPort:    8080,
 			},
+			expectError: true,
+		},
+		{
+			title:       "Ports not specified",
+			redirect:    TrafficRedirectionSpec{},
 			expectError: true,
 		},
 	}
@@ -77,20 +62,6 @@ func Test_validateTrafficRedirect(t *testing.T) {
 	}
 }
 
-func compareCmds(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-
-	for i := 0; i < len(a); i++ {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-
-	return true
-}
-
 func Test_Commands(t *testing.T) {
 	t.Parallel()
 
@@ -106,7 +77,6 @@ func Test_Commands(t *testing.T) {
 		{
 			title: "Start valid redirect",
 			redirect: TrafficRedirectionSpec{
-				Iface:           "eth0",
 				DestinationPort: 80,
 				RedirectPort:    8080,
 			},
@@ -114,9 +84,11 @@ func Test_Commands(t *testing.T) {
 				return tr.Start()
 			},
 			expectedCmds: []string{
-				"iptables -D INPUT -i eth0 -p tcp --dport 8080 -m state --state ESTABLISHED -j REJECT --reject-with tcp-reset",
-				"iptables -A PREROUTING -t nat -i eth0 -p tcp --dport 80 -j REDIRECT --to-port 8080",
-				"iptables -A INPUT -i eth0 -p tcp --dport 80 -m state --state ESTABLISHED -j REJECT --reject-with tcp-reset",
+				"iptables -D INPUT -p tcp --dport 8080 -j REJECT --reject-with tcp-reset",
+				"iptables -A OUTPUT -t nat -s 127.0.0.0/8 -d 127.0.0.1/32 -p tcp --dport 80 -j REDIRECT --to-port 8080",
+				"iptables -A PREROUTING -t nat ! -i lo -p tcp --dport 80 -j REDIRECT --to-port 8080",
+				"iptables -A INPUT -i lo -s 127.0.0.0/8 -d 127.0.0.1/32 -p tcp --dport 80 -m state --state ESTABLISHED -j REJECT --reject-with tcp-reset",
+				"iptables -A INPUT ! -i lo -p tcp --dport 80 -m state --state ESTABLISHED -j REJECT --reject-with tcp-reset",
 			},
 			expectError: false,
 			fakeError:   nil,
@@ -125,7 +97,6 @@ func Test_Commands(t *testing.T) {
 		{
 			title: "Stop active redirect",
 			redirect: TrafficRedirectionSpec{
-				Iface:           "eth0",
 				DestinationPort: 80,
 				RedirectPort:    8080,
 			},
@@ -133,9 +104,11 @@ func Test_Commands(t *testing.T) {
 				return tr.Stop()
 			},
 			expectedCmds: []string{
-				"iptables -D PREROUTING -t nat -i eth0 -p tcp --dport 80 -j REDIRECT --to-port 8080",
-				"iptables -A INPUT -i eth0 -p tcp --dport 8080 -m state --state ESTABLISHED -j REJECT --reject-with tcp-reset",
-				"iptables -D INPUT -i eth0 -p tcp --dport 80 -m state --state ESTABLISHED -j REJECT --reject-with tcp-reset",
+				"iptables -D OUTPUT -t nat -s 127.0.0.0/8 -d 127.0.0.1/32 -p tcp --dport 80 -j REDIRECT --to-port 8080",
+				"iptables -D PREROUTING -t nat ! -i lo -p tcp --dport 80 -j REDIRECT --to-port 8080",
+				"iptables -D INPUT -i lo -s 127.0.0.0/8 -d 127.0.0.1/32 -p tcp --dport 80 -m state --state ESTABLISHED -j REJECT --reject-with tcp-reset",
+				"iptables -D INPUT ! -i lo -p tcp --dport 80 -m state --state ESTABLISHED -j REJECT --reject-with tcp-reset",
+				"iptables -A INPUT -p tcp --dport 8080 -j REJECT --reject-with tcp-reset",
 			},
 			expectError: false,
 			fakeError:   nil,
@@ -144,7 +117,6 @@ func Test_Commands(t *testing.T) {
 		{
 			title: "Error invoking iptables command in Start",
 			redirect: TrafficRedirectionSpec{
-				Iface:           "eth0",
 				DestinationPort: 80,
 				RedirectPort:    8080,
 			},
@@ -159,7 +131,6 @@ func Test_Commands(t *testing.T) {
 		{
 			title: "Error invoking iptables command in Stop",
 			redirect: TrafficRedirectionSpec{
-				Iface:           "eth0",
 				DestinationPort: 80,
 				RedirectPort:    8080,
 			},
@@ -203,13 +174,8 @@ func Test_Commands(t *testing.T) {
 				return
 			}
 
-			if !compareCmds(tc.expectedCmds, executor.CmdHistory()) {
-				t.Errorf(
-					"Actual commands differ from expected:\nExpected:\n\t%s\nActual:\n\t%s",
-					strings.Join(tc.expectedCmds, "\n\t"),
-					strings.Join(executor.CmdHistory(), "\n\t"),
-				)
-				return
+			if diff := cmp.Diff(tc.expectedCmds, executor.CmdHistory()); diff != "" {
+				t.Fatalf("Actual commands differ from expected:\n%s", diff)
 			}
 		})
 	}

--- a/pkg/kubernetes/helpers/pods_test.go
+++ b/pkg/kubernetes/helpers/pods_test.go
@@ -73,7 +73,7 @@ func TestPods_Wait(t *testing.T) {
 			go func(tc TestCase) {
 				pod := builders.NewPodBuilder(tc.name).
 					WithNamespace(testNamespace).
-					WithStatus(tc.status).
+					WithPhase(tc.status).
 					Build()
 				time.Sleep(tc.delay)
 				watcher.Modify(pod)

--- a/pkg/testutils/kubernetes/builders/pod.go
+++ b/pkg/testutils/kubernetes/builders/pod.go
@@ -14,7 +14,7 @@ type PodBuilder interface {
 	// WithLabels sets the labels for the pod to be built
 	WithLabels(labels map[string]string) PodBuilder
 	// WithStatus sets the PodPhase for the pod  to be built
-	WithStatus(status corev1.PodPhase) PodBuilder
+	WithPhase(status corev1.PodPhase) PodBuilder
 	// WithContainer add a container to the pod
 	WithContainer(c corev1.Container) PodBuilder
 }
@@ -24,7 +24,7 @@ type podBuilder struct {
 	name       string
 	namespace  string
 	labels     map[string]string
-	status     corev1.PodPhase
+	phase      corev1.PodPhase
 	containers []corev1.Container
 }
 
@@ -41,8 +41,8 @@ func (b *podBuilder) WithNamespace(namespace string) PodBuilder {
 	return b
 }
 
-func (b *podBuilder) WithStatus(phase corev1.PodPhase) PodBuilder {
-	b.status = phase
+func (b *podBuilder) WithPhase(phase corev1.PodPhase) PodBuilder {
+	b.phase = phase
 	return b
 }
 
@@ -72,7 +72,7 @@ func (b *podBuilder) Build() *corev1.Pod {
 			EphemeralContainers: nil,
 		},
 		Status: corev1.PodStatus{
-			Phase: b.status,
+			Phase: b.phase,
 		},
 	}
 }

--- a/pkg/utils/kubernetes.go
+++ b/pkg/utils/kubernetes.go
@@ -68,3 +68,13 @@ func HasPort(pod corev1.Pod, port uint) bool {
 	}
 	return false
 }
+
+// PodIP returns the pod IP for the supplied pod, or an error if it has no IP (yet).
+func PodIP(pod corev1.Pod) (string, error) {
+	// PodIP must be set if len(PodIPs > 0).
+	if ip := pod.Status.PodIP; ip != "" {
+		return ip, nil
+	}
+
+	return "", fmt.Errorf("pod %s/%s does not have an IP address", pod.Namespace, pod.Name)
+}


### PR DESCRIPTION
# Description

Currently, the disruptor does not support disrupting local traffic, such as that generated through `kubectl port-forward`. 

The main reason for this is that the agent running in the target pods redirects the traffic coming from the `eth0` interface, which is the expected path for the traffic coming from other pods or from outside the cluster.

If we try to address this limitation by redirecting traffic from the `lo` interface, we would also be re-redirecting the egress traffic from the agrent back to itself.

This PR tackles the problem of differentiating the proxy traffic from port-forwarded traffic by not using the network interface as a way of identifying the source of the traffic. Instead, the proxy will differentiate the traffic using the source and destination IPs and will use the pod's IP as a target for the redirected traffic. 

This is an alternative fix for #214.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make test`) and all tests pass.
- [x] I have run relevant e2e test locally (`make e2e-xxx` for `agent`, `disruptors`, `kubernetes` or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
