### PR TITLE
Control e2e cluster lifecycle

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -98,4 +98,5 @@ linters:
     - containedctx
     - usestdlibvars
     - nosprintfhostport
+    - nonamedreturns
   fast: false

--- a/docs/01-development/01-contributing.md
+++ b/docs/01-development/01-contributing.md
@@ -191,11 +191,6 @@ func Test_E2E(t *testing.T) {
 	        return
         }
 
-	// delete cluster when all sub-tests end
-	t.Cleanup(func() {
-		_ = cluster.Delete()
-	})
-
 	// get kubernetes client
 	k8s, err := kubernetes.NewFromKubeconfig(cluster.Kubeconfig())
 	if err != nil {
@@ -240,3 +235,7 @@ The port to be exposed by the test cluster can be changed using the `WithIngress
 		cluster.WithIngressPort(30083),
 	)
 ```
+
+### Debugging e2e tests
+
+By default, once the e2e test is completed, the test cluster is deleted. This is inconvenient for debugging failed tests. This behavior is controlled by the `AutoCleanup` option in the `E2eClusterConfig`. By default it is true. This option can be disable using the `WithAutoCleanup(false)` option in the `BuildE2eCluster` function or by setting `E2E_AUTOCLEANUP=false` in your environment.

--- a/e2e/agent/agent_e2e_test.go
+++ b/e2e/agent/agent_e2e_test.go
@@ -165,6 +165,7 @@ func builDisruptorService() *corev1.Service {
 
 func Test_Agent(t *testing.T) {
 	cluster, err := cluster.BuildE2eCluster(
+		t,
 		cluster.DefaultE2eClusterConfig(),
 		cluster.WithName("e2e-xk6-agent"),
 		cluster.WithIngressPort(30080),
@@ -173,10 +174,6 @@ func Test_Agent(t *testing.T) {
 		t.Errorf("failed to create e2e cluster: %v", err)
 		return
 	}
-
-	t.Cleanup(func() {
-		_ = cluster.Delete()
-	})
 
 	k8s, err := kubernetes.NewFromKubeconfig(cluster.Kubeconfig())
 	if err != nil {

--- a/e2e/cluster/cluster_e2e_test.go
+++ b/e2e/cluster/cluster_e2e_test.go
@@ -172,3 +172,38 @@ func Test_InvalidKubernetesVersion(t *testing.T) {
 		return
 	}
 }
+
+// FIXME: this is a very basic test. Check for error conditions and ensure
+// returned cluster is functional.
+func Test_GetCluster(t *testing.T) {
+	// create cluster with  configuration
+	config, err := cluster.NewConfig(
+		"e2e-preexisting-cluster",
+		cluster.Options{
+			Wait: time.Second * 60,
+		},
+	)
+	if err != nil {
+		t.Errorf("failed creating cluster configuration: %v", err)
+		return
+	}
+
+	c, err := config.Create()
+	if err != nil {
+		t.Errorf("failed to create cluster: %v", err)
+		return
+	}
+
+	cluster, err := cluster.GetCluster(c.Name(), c.Kubeconfig())
+	if err != nil {
+		t.Errorf("failed to get cluster: %v", err)
+		return
+	}
+
+	// delete cluster
+	cluster.Delete()
+	if err != nil {
+		t.Errorf("failed to delete cluster: %v", err)
+		return
+	}
+}

--- a/e2e/disruptors/pod_e2e_test.go
+++ b/e2e/disruptors/pod_e2e_test.go
@@ -24,6 +24,7 @@ func Test_PodDisruptor(t *testing.T) {
 	t.Parallel()
 
 	cluster, err := cluster.BuildE2eCluster(
+		t,
 		cluster.DefaultE2eClusterConfig(),
 		cluster.WithName("e2e-pod-disruptor"),
 		cluster.WithIngressPort(30082),
@@ -32,10 +33,6 @@ func Test_PodDisruptor(t *testing.T) {
 		t.Errorf("failed to create cluster: %v", err)
 		return
 	}
-
-	t.Cleanup(func() {
-		_ = cluster.Delete()
-	})
 
 	k8s, err := kubernetes.NewFromKubeconfig(cluster.Kubeconfig())
 	if err != nil {

--- a/e2e/disruptors/service_e2e_test.go
+++ b/e2e/disruptors/service_e2e_test.go
@@ -22,6 +22,7 @@ import (
 
 func Test_ServiceDisruptor(t *testing.T) {
 	cluster, err := cluster.BuildE2eCluster(
+		t,
 		cluster.DefaultE2eClusterConfig(),
 		cluster.WithName("e2e-service-disruptor"),
 		cluster.WithIngressPort(30083),
@@ -30,10 +31,6 @@ func Test_ServiceDisruptor(t *testing.T) {
 		t.Errorf("failed to create cluster: %v", err)
 		return
 	}
-
-	t.Cleanup(func() {
-		_ = cluster.Delete()
-	})
 
 	k8s, err := kubernetes.NewFromKubeconfig(cluster.Kubeconfig())
 	if err != nil {

--- a/e2e/kubernetes/kubernetes_e2e_test.go
+++ b/e2e/kubernetes/kubernetes_e2e_test.go
@@ -22,6 +22,7 @@ import (
 
 func Test_Kubernetes(t *testing.T) {
 	cluster, err := cluster.BuildE2eCluster(
+		t,
 		cluster.DefaultE2eClusterConfig(),
 		cluster.WithName("e2e-kubernetes"),
 		cluster.WithIngressPort(30081),
@@ -30,10 +31,6 @@ func Test_Kubernetes(t *testing.T) {
 		t.Errorf("failed to create cluster: %v", err)
 		return
 	}
-
-	t.Cleanup(func() {
-		_ = cluster.Delete()
-	})
 
 	k8s, err := kubernetes.NewFromKubeconfig(cluster.Kubeconfig())
 	if err != nil {

--- a/pkg/testutils/e2e/cluster/cluster.go
+++ b/pkg/testutils/e2e/cluster/cluster.go
@@ -229,20 +229,3 @@ func (c *e2eCluster) Kubeconfig() string {
 	return c.cluster.Kubeconfig()
 }
 
-// BuildCluster builds a cluster with the xk6-disruptor-agent image preloaded and
-// the given node ports exposed
-func BuildCluster(name string, ports ...cluster.NodePort) (*cluster.Cluster, error) {
-	config, err := cluster.NewConfig(
-		name,
-		cluster.Options{
-			Images:    []string{"ghcr.io/grafana/xk6-disruptor-agent:latest"},
-			Wait:      time.Second * 60,
-			NodePorts: ports,
-		},
-	)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create cluster config: %w", err)
-	}
-
-	return config.Create()
-}

--- a/pkg/utils/env.go
+++ b/pkg/utils/env.go
@@ -8,9 +8,9 @@ import (
 // GetBooleanEnvVar returns a boolean environment variable.
 // If variable is not set or invalid value, returns the default value
 func GetBooleanEnvVar(envVar string, defaultValue bool) bool {
-	autoCleanup, err := strconv.ParseBool(os.Getenv(envVar))
+	value, err := strconv.ParseBool(os.Getenv(envVar))
 	if err != nil {
 		return defaultValue
 	}
-	return autoCleanup
+	return value
 }

--- a/pkg/utils/env.go
+++ b/pkg/utils/env.go
@@ -1,0 +1,16 @@
+package utils
+
+import (
+	"os"
+	"strconv"
+)
+
+// GetBooleanEnvVar returns a boolean environment variable.
+// If variable is not set or invalid value, returns the default value
+func GetBooleanEnvVar(envVar string, defaultValue bool) bool {
+	autoCleanup, err := strconv.ParseBool(os.Getenv(envVar))
+	if err != nil {
+		return defaultValue
+	}
+	return autoCleanup
+}


### PR DESCRIPTION
# Description

Presently, e2e tests automatically create a cluster and automatically delete it when tests are finished.

This PR introduces options controlled by environment variables, to change this default behavior and control the lifecycle of e2e test clusters. 

Note: These changes were tested by issuing the following commands:

```sh
# check if the cluster exists
kind get clusters
No kind clusters found.

# run e2e test and retain cluster
E2E_AUTOCLEANUP=false E2E_REUSE=true go test -tags e2e e2e/agent/agent.go -count 1
ok  	command-line-arguments	131.859s

# check the cluster is still there after the test
kind get clusters
e2e-xk6-agent

# run again the test, reuse the cluster, delete at the end
E2E_AUTOCLEANUP=true E2E_REUSE=true go test -tags e2e e2e/agent/agent.go -count 1
ok  	command-line-arguments	5.011s

# check if the cluster was deleted
kind get clusters
No kind clusters found.
```
Fixes #191 

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works.   
- [X] I have run linter locally (`make lint`) and all checks pass.
- [X] I have run tests locally (`make test`) and all tests pass.
- [X] I have run relevant e2e test locally (`make e2e-xxx` for `agent`, `disruptors`, `kubernetes` or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
