### PR TITLE
Add golangci to renovate configuration

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -5,6 +5,15 @@
   ],
   "gomod": {}, // Upgrade go dependencies.
   "github-actions": {}, // Upgrade GitHub actions.
+  "regexManagers": [
+    // Custom golangci version in .golangci.yml comment.
+    {
+      "fileMatch": [".golangci.ya?ml$"],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "golangci/golangci-lint",
+      "matchStrings": ["^# (?<currentValue>v[\\w-.]+)"]
+    }
+  ],
   // Renovate evaluates all packageRules and does not stop after the first match.
   // Rules that appear later in this list override earlier rules.
   "packageRules": [


### PR DESCRIPTION
# Description

This PR instructs renovate to check golangci-lint tag from the comment in `.golangci.yml`.

Demo PR: https://github.com/roobre/xk6-disruptor/pull/14

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make test`) and all tests pass.
- [ ] I have run relevant e2e test locally (`make e2e-xxx` for `agent`, `disruptors`, `kubernetes` or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
