### PR TITLE
Change port defaults in agent

### DIFF
--- a/cmd/agent/commands/grpc.go
+++ b/cmd/agent/commands/grpc.go
@@ -31,6 +31,9 @@ func BuildGrpcCmd(env runtime.Environment, config *agent.Config) *cobra.Command 
 			" When running as a transparent proxy requires NET_ADMIM capabilities for setting" +
 			" iptable rules.",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if target == 0 {
+				return fmt.Errorf("target port for fault injection is required")
+			}
 			listenAddress := fmt.Sprintf(":%d", port)
 			upstreamAddress := fmt.Sprintf("%s:%d", upstreamHost, target)
 
@@ -83,7 +86,7 @@ func BuildGrpcCmd(env runtime.Environment, config *agent.Config) *cobra.Command 
 	cmd.Flags().StringVarP(&disruption.StatusMessage, "message", "m", "", "error message for injected faults")
 	cmd.Flags().StringVarP(&iface, "interface", "i", "eth0", "interface to disrupt")
 	cmd.Flags().UintVarP(&port, "port", "p", 8080, "port the proxy will listen to")
-	cmd.Flags().UintVarP(&target, "target", "t", 80, "port the proxy will redirect request to")
+	cmd.Flags().UintVarP(&target, "target", "t", 0, "port the proxy will redirect request to")
 	cmd.Flags().StringSliceVarP(&disruption.Excluded, "exclude", "x", []string{}, "comma-separated list of grpc services"+
 		" to be excluded from disruption")
 	cmd.Flags().BoolVar(&transparent, "transparent", true, "run as transparent proxy")

--- a/cmd/agent/commands/grpc.go
+++ b/cmd/agent/commands/grpc.go
@@ -85,7 +85,7 @@ func BuildGrpcCmd(env runtime.Environment, config *agent.Config) *cobra.Command 
 	cmd.Flags().Float32VarP(&disruption.ErrorRate, "rate", "r", 0, "error rate")
 	cmd.Flags().StringVarP(&disruption.StatusMessage, "message", "m", "", "error message for injected faults")
 	cmd.Flags().StringVarP(&iface, "interface", "i", "eth0", "interface to disrupt")
-	cmd.Flags().UintVarP(&port, "port", "p", 8080, "port the proxy will listen to")
+	cmd.Flags().UintVarP(&port, "port", "p", 8000, "port the proxy will listen to")
 	cmd.Flags().UintVarP(&target, "target", "t", 0, "port the proxy will redirect request to")
 	cmd.Flags().StringSliceVarP(&disruption.Excluded, "exclude", "x", []string{}, "comma-separated list of grpc services"+
 		" to be excluded from disruption")

--- a/cmd/agent/commands/http.go
+++ b/cmd/agent/commands/http.go
@@ -30,6 +30,9 @@ func BuildHTTPCmd(env runtime.Environment, config *agent.Config) *cobra.Command 
 			" When running as a transparent proxy requires NET_ADMIM capabilities for setting" +
 			" iptable rules.",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if target == 0 {
+				return fmt.Errorf("target port for fault injection is required")
+			}
 			listenAddress := fmt.Sprintf(":%d", port)
 			upstreamAddress := fmt.Sprintf("http://%s:%d", upstreamHost, target)
 
@@ -88,7 +91,7 @@ func BuildHTTPCmd(env runtime.Environment, config *agent.Config) *cobra.Command 
 		"upstream host to redirect traffic to")
 	cmd.Flags().StringVarP(&iface, "interface", "i", "eth0", "interface to disrupt")
 	cmd.Flags().UintVarP(&port, "port", "p", 8080, "port the proxy will listen to")
-	cmd.Flags().UintVarP(&target, "target", "t", 80, "port the proxy will redirect request to")
+	cmd.Flags().UintVarP(&target, "target", "t", 0, "port the proxy will redirect request to")
 
 	return cmd
 }

--- a/cmd/agent/commands/http.go
+++ b/cmd/agent/commands/http.go
@@ -90,7 +90,7 @@ func BuildHTTPCmd(env runtime.Environment, config *agent.Config) *cobra.Command 
 	cmd.Flags().StringVar(&upstreamHost, "upstream-host", "localhost",
 		"upstream host to redirect traffic to")
 	cmd.Flags().StringVarP(&iface, "interface", "i", "eth0", "interface to disrupt")
-	cmd.Flags().UintVarP(&port, "port", "p", 8080, "port the proxy will listen to")
+	cmd.Flags().UintVarP(&port, "port", "p", 8000, "port the proxy will listen to")
 	cmd.Flags().UintVarP(&target, "target", "t", 0, "port the proxy will redirect request to")
 
 	return cmd


### PR DESCRIPTION
# Description

Make the target port required and use port `8000` as the default for the proxy to listen to.

Fixes #161 

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation https://github.com/grafana/k6-docs/pull/1243
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [X] I have run linter locally (`make lint`) and all checks pass.
- [X] I have run tests locally (`make test`) and all tests pass.
- [X] I have run relevant e2e test locally (`make e2e-xxx` for `agent`, `disruptors`, `kubernetes` or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
