### PR TITLE
Allow access to pods using port forwarder

### DIFF
--- a/e2e/kubectl/kubectl_e2e_test.go
+++ b/e2e/kubectl/kubectl_e2e_test.go
@@ -1,0 +1,101 @@
+//go:build e2e
+// +build e2e
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/grafana/xk6-disruptor/pkg/kubernetes"
+	"github.com/grafana/xk6-disruptor/pkg/testutils/e2e/cluster"
+	"github.com/grafana/xk6-disruptor/pkg/testutils/e2e/deploy"
+	"github.com/grafana/xk6-disruptor/pkg/testutils/e2e/kubectl"
+	"github.com/grafana/xk6-disruptor/pkg/testutils/e2e/kubernetes/namespace"
+	"github.com/grafana/xk6-disruptor/pkg/testutils/kubernetes/builders"
+)
+
+func Test_Kubectl(t *testing.T) {
+	cluster, err := cluster.BuildE2eCluster(
+		t,
+		cluster.DefaultE2eClusterConfig(),
+		cluster.WithName("e2e-kubectl"),
+		cluster.WithIngressPort(30087),
+	)
+	if err != nil {
+		t.Errorf("failed to create cluster: %v", err)
+		return
+	}
+
+	k8s, err := kubernetes.NewFromKubeconfig(cluster.Kubeconfig())
+	if err != nil {
+		t.Errorf("error creating kubernetes client: %v", err)
+		return
+	}
+
+	// Test Wait Pod Running
+	t.Run("Test local random port", func(t *testing.T) {
+		namespace, err := namespace.CreateTestNamespace(context.TODO(), t, k8s.Client())
+		if err != nil {
+			t.Errorf("failed to create test namespace: %v", err)
+			return
+		}
+
+		// Deploy nginx
+		nginx := builders.NewPodBuilder("nginx").
+			WithContainer(
+				*builders.NewContainerBuilder("nginx").
+				WithImage("nginx").
+				WithPort("http", 80).
+				Build(),
+			).
+			Build()
+
+		err = deploy.RunPod(k8s, namespace, nginx, 20 * time.Second)
+		if err != nil {
+			t.Errorf("failed to create test pod: %v", err)
+			return
+		}
+
+		client, err := kubectl.NewFromKubeconfig(context.TODO(), cluster.Kubeconfig() )
+		if err != nil {
+			t.Errorf("failed to create kubectl client: %v", err)
+			return
+		}
+
+		ctx, stopper := context.WithCancel(context.TODO())
+		// ensure por forwarder is cancelled
+		defer stopper()
+
+		port, err := client.ForwardPodPort(ctx, nginx.GetName(), namespace, 80)
+		if err != nil {
+			t.Errorf("failed to forward local port: %v", err)
+			return
+		}
+		
+		url := fmt.Sprintf("http://localhost:%d", port)
+		request, err := http.NewRequest("GET", url, bytes.NewReader([]byte{}))
+		if err != nil {
+			t.Errorf("failed to create request: %v", err)
+			return
+		}
+	
+		resp, err := http.DefaultClient.Do(request)
+		if err != nil {
+			t.Errorf("failed make request: %v", err)
+			return
+		}
+		defer func() {
+			_ = resp.Body.Close()
+		}()
+	
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("expected status code %d but %d received", http.StatusOK, resp.StatusCode)
+			return
+		}
+	})
+}

--- a/e2e/kubectl/kubectl_e2e_test.go
+++ b/e2e/kubectl/kubectl_e2e_test.go
@@ -71,7 +71,7 @@ func Test_Kubectl(t *testing.T) {
 		// ensure por forwarder is cancelled
 		defer stopper()
 
-		port, err := client.ForwardPodPort(ctx, nginx.GetName(), namespace, 80)
+		port, err := client.ForwardPodPort(ctx, namespace, nginx.GetName(), 80)
 		if err != nil {
 			t.Errorf("failed to forward local port: %v", err)
 			return

--- a/pkg/testutils/e2e/kubectl/kubectl.go
+++ b/pkg/testutils/e2e/kubectl/kubectl.go
@@ -230,8 +230,8 @@ func newPortForwardConfig(opts ...PortForwardOption) portForwardConfig {
 // Returns the local port used for listening
 func (c *Client) ForwardPodPort(
 	ctx context.Context,
-	pod string,
 	namespace string,
+	pod string,
 	port uint,
 	opts ...PortForwardOption,
 ) (uint, error) {
@@ -278,7 +278,7 @@ func (c *Client) ForwardPodPort(
 		errors <- fw.ForwardPorts()
 	}()
 
-	// Wait for the port forwarder to be ready and return stop channel
+	// Wait for the port forwarder to be ready to return port
 	select {
 	case <-ready:
 		// return the local port (we are waiting for ready, so no error expected)


### PR DESCRIPTION
# Description

Implements test util for accessing pods in a test cluster using a port forwarder. 
Required for testing #231 

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works.   
- [X] I have run linter locally (`make lint`) and all checks pass.
- [X] I have run tests locally (`make test`) and all tests pass.
- [ ] I have run relevant e2e test locally (`make e2e-xxx` for `agent`, `disruptors`, `kubernetes` or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
