### PR TITLE
Remove target address option

### DIFF
--- a/pkg/disruptors/cmd_builders.go
+++ b/pkg/disruptors/cmd_builders.go
@@ -7,7 +7,12 @@ import (
 	"github.com/grafana/xk6-disruptor/pkg/utils"
 )
 
-func buildGrpcFaultCmd(fault GrpcFault, duration time.Duration, options GrpcDisruptionOptions) []string {
+func buildGrpcFaultCmd(
+	targetAddress string,
+	fault GrpcFault,
+	duration time.Duration,
+	options GrpcDisruptionOptions,
+) []string {
 	cmd := []string{
 		"xk6-disruptor-agent",
 		"grpc",
@@ -51,14 +56,17 @@ func buildGrpcFaultCmd(fault GrpcFault, duration time.Duration, options GrpcDisr
 		cmd = append(cmd, "-p", fmt.Sprint(options.ProxyPort))
 	}
 
-	if options.TargetAddress != "" {
-		cmd = append(cmd, "--upstream-host", options.TargetAddress)
-	}
+	cmd = append(cmd, "--upstream-host", targetAddress)
 
 	return cmd
 }
 
-func buildHTTPFaultCmd(fault HTTPFault, duration time.Duration, options HTTPDisruptionOptions) []string {
+func buildHTTPFaultCmd(
+	targetAddress string,
+	fault HTTPFault,
+	duration time.Duration,
+	options HTTPDisruptionOptions,
+) []string {
 	cmd := []string{
 		"xk6-disruptor-agent",
 		"http",
@@ -101,9 +109,7 @@ func buildHTTPFaultCmd(fault HTTPFault, duration time.Duration, options HTTPDisr
 		cmd = append(cmd, "-p", fmt.Sprint(options.ProxyPort))
 	}
 
-	if options.TargetAddress != "" {
-		cmd = append(cmd, "--upstream-host", options.TargetAddress)
-	}
+	cmd = append(cmd, "--upstream-host", targetAddress)
 
 	return cmd
 }

--- a/pkg/disruptors/pod.go
+++ b/pkg/disruptors/pod.go
@@ -124,13 +124,12 @@ func (d *podDisruptor) InjectHTTPFaults(
 			return nil, fmt.Errorf("pod %q does not expose port %d", pod.Name, fault.Port)
 		}
 
-		var err error
-		options.TargetAddress, err = utils.PodIP(pod)
+		targetAddress, err := utils.PodIP(pod)
 		if err != nil {
 			return nil, err
 		}
 
-		cmd := buildHTTPFaultCmd(fault, duration, options)
+		cmd := buildHTTPFaultCmd(targetAddress, fault, duration, options)
 
 		return cmd, nil
 	})
@@ -148,13 +147,12 @@ func (d *podDisruptor) InjectGrpcFaults(
 			return nil, fmt.Errorf("pod %q does not expose port %d", pod.Name, fault.Port)
 		}
 
-		var err error
-		options.TargetAddress, err = utils.PodIP(pod)
+		targetAddress, err := utils.PodIP(pod)
 		if err != nil {
 			return nil, err
 		}
 
-		cmd := buildGrpcFaultCmd(fault, duration, options)
+		cmd := buildGrpcFaultCmd(targetAddress, fault, duration, options)
 		return cmd, nil
 	})
 }

--- a/pkg/disruptors/protocol.go
+++ b/pkg/disruptors/protocol.go
@@ -17,18 +17,12 @@ type ProtocolFaultInjector interface {
 
 // HTTPDisruptionOptions defines options for the injection of HTTP faults in a target pod
 type HTTPDisruptionOptions struct {
-	// IP address where the proxy will send requests.
-	// This is typically the pod IP. It must not be `localhost`.
-	TargetAddress string
 	// Port used by the agent for listening
 	ProxyPort uint `js:"proxyPort"`
 }
 
 // GrpcDisruptionOptions defines options for the injection of grpc faults in a target pod
 type GrpcDisruptionOptions struct {
-	// IP address where the proxy will send requests.
-	// This is typically the pod IP. It must not be `localhost`.
-	TargetAddress string
 	// Port used by the agent for listening
 	ProxyPort uint `js:"proxyPort"`
 }

--- a/pkg/disruptors/service.go
+++ b/pkg/disruptors/service.go
@@ -100,12 +100,12 @@ func (d *serviceDisruptor) InjectHTTPFaults(
 		podFault := fault
 		podFault.Port = port
 
-		options.TargetAddress, err = utils.PodIP(pod)
+		targetAddress, err := utils.PodIP(pod)
 		if err != nil {
 			return nil, err
 		}
 
-		cmd := buildHTTPFaultCmd(fault, duration, options)
+		cmd := buildHTTPFaultCmd(targetAddress, fault, duration, options)
 		return cmd, nil
 	})
 }
@@ -127,12 +127,12 @@ func (d *serviceDisruptor) InjectGrpcFaults(
 		podFault := fault
 		podFault.Port = port
 
-		options.TargetAddress, err = utils.PodIP(pod)
+		targetAddress, err := utils.PodIP(pod)
 		if err != nil {
 			return nil, err
 		}
 
-		cmd := buildGrpcFaultCmd(fault, duration, options)
+		cmd := buildGrpcFaultCmd(targetAddress, fault, duration, options)
 		return cmd, nil
 	})
 }


### PR DESCRIPTION
# Description

The `TargetAddress` option introduced in #231 should not be exposed to the API, as there's no case for the user to set it.

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [X] I have run linter locally (`make lint`) and all checks pass.
- [X] I have run tests locally (`make test`) and all tests pass.
- [X] I have run relevant e2e test locally (`make e2e-xxx` for `agent`, `disruptors`, `kubernetes` or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
