### PR TITLE
disruptors: refuse to inject a fault on pods with hostNetwork set to true

### DIFF
--- a/pkg/disruptors/pod.go
+++ b/pkg/disruptors/pod.go
@@ -124,6 +124,10 @@ func (d *podDisruptor) InjectHTTPFaults(
 			return nil, fmt.Errorf("pod %q does not expose port %d", pod.Name, fault.Port)
 		}
 
+		if utils.HasHostNetwork(pod) {
+			return nil, fmt.Errorf("pod %q cannot be safely injected as it has hostNetwork set to true", pod.Name)
+		}
+
 		targetAddress, err := utils.PodIP(pod)
 		if err != nil {
 			return nil, err

--- a/pkg/disruptors/pod_test.go
+++ b/pkg/disruptors/pod_test.go
@@ -247,6 +247,36 @@ func Test_PodHTTPFaultInjection(t *testing.T) {
 			opts:     HTTPDisruptionOptions{},
 			duration: 60,
 		},
+		{
+			title: "Pod with hostNetwork",
+			selector: PodSelector{
+				Namespace: "testns",
+				Select: PodAttributes{
+					Labels: map[string]string{
+						"app": "myapp",
+					},
+				},
+			},
+			target: builders.NewPodBuilder("hostnet").
+				WithNamespace("test-ns").
+				WithLabels(map[string]string{
+					"app": "myapp",
+				}).
+				WithHostNetwork(true).
+				WithIP("192.0.2.6").
+				WithContainer(
+					*builders.NewContainerBuilder("myapp").
+						WithPort("http", 80).
+						Build(),
+				).
+				Build(),
+			expectError: true,
+			fault: HTTPFault{
+				Port: 80,
+			},
+			opts:     HTTPDisruptionOptions{},
+			duration: 60,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/disruptors/service.go
+++ b/pkg/disruptors/service.go
@@ -96,6 +96,10 @@ func (d *serviceDisruptor) InjectHTTPFaults(
 			return nil, err
 		}
 
+		if utils.HasHostNetwork(pod) {
+			return nil, fmt.Errorf("pod %q cannot be safely injected as it has hostNetwork set to true", pod.Name)
+		}
+
 		// copy fault to change target port for the pod
 		podFault := fault
 		podFault.Port = port

--- a/pkg/testutils/kubernetes/builders/pod.go
+++ b/pkg/testutils/kubernetes/builders/pod.go
@@ -17,18 +17,21 @@ type PodBuilder interface {
 	WithPhase(status corev1.PodPhase) PodBuilder
 	// WithIP sets the IP address for the pod to be built
 	WithIP(ip string) PodBuilder
+	// WithHostNetwork sets the hostNetwork property of the pod to be built
+	WithHostNetwork(hostNetwork bool) PodBuilder
 	// WithContainer add a container to the pod
 	WithContainer(c corev1.Container) PodBuilder
 }
 
 // podBuilder defines the attributes for building a pod
 type podBuilder struct {
-	name       string
-	namespace  string
-	labels     map[string]string
-	phase      corev1.PodPhase
-	ip         string
-	containers []corev1.Container
+	name        string
+	namespace   string
+	labels      map[string]string
+	phase       corev1.PodPhase
+	ip          string
+	hostNetwork bool
+	containers  []corev1.Container
 }
 
 // NewPodBuilder creates a new instance of PodBuilder with the given pod name
@@ -59,6 +62,11 @@ func (b *podBuilder) WithLabels(labels map[string]string) PodBuilder {
 	return b
 }
 
+func (b *podBuilder) WithHostNetwork(hostNetwork bool) PodBuilder {
+	b.hostNetwork = hostNetwork
+	return b
+}
+
 func (b *podBuilder) WithContainer(c corev1.Container) PodBuilder {
 	b.containers = append(b.containers, c)
 	return b
@@ -77,6 +85,7 @@ func (b *podBuilder) Build() *corev1.Pod {
 		},
 		Spec: corev1.PodSpec{
 			Containers:          b.containers,
+			HostNetwork:         b.hostNetwork,
 			EphemeralContainers: nil,
 		},
 		Status: corev1.PodStatus{

--- a/pkg/utils/kubernetes.go
+++ b/pkg/utils/kubernetes.go
@@ -69,6 +69,11 @@ func HasPort(pod corev1.Pod, port uint) bool {
 	return false
 }
 
+// HasHostNetwork returns whether a pod has HostNetwork enabled, i.e. it shares the host's network namespace.
+func HasHostNetwork(pod corev1.Pod) bool {
+	return pod.Spec.HostNetwork
+}
+
 // PodIP returns the pod IP for the supplied pod, or an error if it has no IP (yet).
 func PodIP(pod corev1.Pod) (string, error) {
 	// PodIP must be set if len(PodIPs > 0).


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change including related open issues or other open PRs. -->

<!--- If implementing a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it -->
Fixes #216 

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works.   
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make test`) and all tests pass.
- [x] I have run relevant e2e test locally (`make e2e-xxx` for `agent`, `disruptors`, `kubernetes` or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      

