### PR TITLE
disruptors/service: fix mapped port propagation

### DIFF
--- a/pkg/disruptors/service.go
+++ b/pkg/disruptors/service.go
@@ -109,7 +109,7 @@ func (d *serviceDisruptor) InjectHTTPFaults(
 			return nil, err
 		}
 
-		cmd := buildHTTPFaultCmd(targetAddress, fault, duration, options)
+		cmd := buildHTTPFaultCmd(targetAddress, podFault, duration, options)
 		return cmd, nil
 	})
 }
@@ -136,7 +136,7 @@ func (d *serviceDisruptor) InjectGrpcFaults(
 			return nil, err
 		}
 
-		cmd := buildGrpcFaultCmd(targetAddress, fault, duration, options)
+		cmd := buildGrpcFaultCmd(targetAddress, podFault, duration, options)
 		return cmd, nil
 	})
 }


### PR DESCRIPTION
# Description

Fixes a bug that caused ServiceDisruptors to output the following error if a port was not specified:

```
ERRO[0004] GoError: error injecting fault: error invoking agent: command terminated with exit code 1
target port for fault injection is required
```

The expected behavior was for the port to be autodetected if the service only has one.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works.   
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make test`) and all tests pass.
- [ ] I have run relevant e2e test locally (`make e2e-xxx` for `agent`, `disruptors`, `kubernetes` or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
