### PR TITLE
cmd: change default proxyPort back to 8000

### DIFF
--- a/cmd/agent/commands/grpc.go
+++ b/cmd/agent/commands/grpc.go
@@ -91,7 +91,7 @@ func BuildGrpcCmd(env runtime.Environment, config *agent.Config) *cobra.Command 
 	cmd.Flags().Int32VarP(&disruption.StatusCode, "status", "s", 0, "status code")
 	cmd.Flags().Float32VarP(&disruption.ErrorRate, "rate", "r", 0, "error rate")
 	cmd.Flags().StringVarP(&disruption.StatusMessage, "message", "m", "", "error message for injected faults")
-	cmd.Flags().UintVarP(&port, "port", "p", 8080, "port the proxy will listen to")
+	cmd.Flags().UintVarP(&port, "port", "p", 8000, "port the proxy will listen to")
 	cmd.Flags().UintVarP(&targetPort, "target", "t", 0, "port the proxy will redirect request to")
 	cmd.Flags().StringSliceVarP(&disruption.Excluded, "exclude", "x", []string{}, "comma-separated list of grpc services"+
 		" to be excluded from disruption")

--- a/cmd/agent/commands/http.go
+++ b/cmd/agent/commands/http.go
@@ -96,7 +96,7 @@ func BuildHTTPCmd(env runtime.Environment, config *agent.Config) *cobra.Command 
 	cmd.Flags().BoolVar(&transparent, "transparent", true, "run as transparent proxy")
 	cmd.Flags().StringVar(&upstreamHost, "upstream-host", "localhost",
 		"upstream host to redirect traffic to")
-	cmd.Flags().UintVarP(&port, "port", "p", 8080, "port the proxy will listen to")
+	cmd.Flags().UintVarP(&port, "port", "p", 8000, "port the proxy will listen to")
 	cmd.Flags().UintVarP(&targetPort, "target", "t", 0, "port the proxy will redirect request to")
 
 	return cmd


### PR DESCRIPTION
# Description

This PR restores the default proxyPort back to 8000 as it was intended to be as per d69514d0892ca8d731025c1c4dc97976a37f5b85. This port was accidentally changed back to 8080 during #249 

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make test`) and all tests pass.
- [x] I have run relevant e2e test locally (`make e2e-xxx` for `agent`, `disruptors`, `kubernetes` or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
