### PR TITLE
disruptors: error out if there are no targets

### DIFF
--- a/pkg/disruptors/pod.go
+++ b/pkg/disruptors/pod.go
@@ -3,8 +3,10 @@ package disruptors
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	"github.com/grafana/xk6-disruptor/pkg/kubernetes"
@@ -17,6 +19,10 @@ import (
 
 // DefaultTargetPort defines default target port if not specified in Fault
 const DefaultTargetPort = 80
+
+// ErrSelectorNoPods is returned by NewPodDisruptor when the selector passed to it does not match any pod in the
+// cluster.
+var ErrSelectorNoPods = errors.New("no pods found matching selector")
 
 // PodDisruptor defines the types of faults that can be injected in a Pod
 type PodDisruptor interface {
@@ -50,6 +56,52 @@ type PodAttributes struct {
 	Labels map[string]string
 }
 
+// NamespaceOrDefault returns the configured namespace for this selector, and the name of the default namespace if it
+// is not configured.
+func (p PodSelector) NamespaceOrDefault() string {
+	if p.Namespace != "" {
+		return p.Namespace
+	}
+
+	return metav1.NamespaceDefault
+}
+
+// String returns a human-readable explanation of the pods matched by a PodSelector.
+func (p PodSelector) String() string {
+	var str string
+
+	if len(p.Select.Labels) == 0 && len(p.Exclude.Labels) == 0 {
+		str = "all pods"
+	} else {
+		str = "pods "
+		str += p.groupLabels("including", p.Select.Labels)
+		str += p.groupLabels("excluding", p.Exclude.Labels)
+		str = strings.TrimSuffix(str, ", ")
+	}
+
+	str += fmt.Sprintf(" in ns %q", p.NamespaceOrDefault())
+
+	return str
+}
+
+// groupLabels returns a group of labels as a string, giving that group a name. The returned string has the form of:
+// `groupName(foo=bar, boo=baz), `, including the trailing space and comma.
+// An empty group of labels produces an empty string.
+func (PodSelector) groupLabels(groupName string, labels map[string]string) string {
+	if len(labels) == 0 {
+		return ""
+	}
+
+	group := groupName + "("
+	for k, v := range labels {
+		group += fmt.Sprintf("%s=%s, ", k, v)
+	}
+	group = strings.TrimSuffix(group, ", ")
+	group += "), "
+
+	return group
+}
+
 // NewPodDisruptor creates a new instance of a PodDisruptor that acts on the pods
 // that match the given PodSelector
 func NewPodDisruptor(
@@ -66,10 +118,7 @@ func NewPodDisruptor(
 	}
 
 	// ensure selector and controller use default namespace if none specified
-	namespace := selector.Namespace
-	if selector.Namespace == "" {
-		selector.Namespace = metav1.NamespaceDefault
-	}
+	namespace := selector.NamespaceOrDefault()
 	helper := k8s.PodHelper(namespace)
 
 	filter := helpers.PodFilter{
@@ -80,6 +129,10 @@ func NewPodDisruptor(
 	targets, err := helper.List(ctx, filter)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(targets) == 0 {
+		return nil, fmt.Errorf("finding pods matching '%s': %w", selector, ErrSelectorNoPods)
 	}
 
 	controller := NewAgentController(

--- a/pkg/disruptors/pod_test.go
+++ b/pkg/disruptors/pod_test.go
@@ -3,14 +3,18 @@ package disruptors
 import (
 	"context"
 	"fmt"
+	"sort"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/grafana/xk6-disruptor/pkg/kubernetes"
 	"github.com/grafana/xk6-disruptor/pkg/runtime"
 	"github.com/grafana/xk6-disruptor/pkg/testutils/command"
 	"github.com/grafana/xk6-disruptor/pkg/testutils/kubernetes/builders"
-
 	corev1 "k8s.io/api/core/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
 )
 
 type fakeAgentController struct {
@@ -373,6 +377,148 @@ func Test_PodGrpcPFaultInjection(t *testing.T) {
 			cmd := executor.Cmd()
 			if !command.AssertCmdEquals(tc.expectedCmd, cmd) {
 				t.Errorf("expected command: %s got: %s", tc.expectedCmd, cmd)
+			}
+		})
+	}
+}
+
+func Test_NewPodDisruptor(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		title       string
+		name        string
+		namespace   string
+		pods        []corev1.Pod
+		selector    PodSelector
+		expectError bool
+		expected    []string
+	}{
+		{
+			title:     "matching pods",
+			name:      "test-svc",
+			namespace: "test-ns",
+			pods: []corev1.Pod{
+				builders.NewPodBuilder("pod-1").
+					WithNamespace("test-ns").
+					WithLabel("app", "test").
+					WithIP("192.0.2.6").
+					Build(),
+			},
+			selector: PodSelector{
+				Namespace: "test-ns",
+				Select: PodAttributes{Labels: map[string]string{
+					"app": "test",
+				}},
+			},
+			expectError: false,
+			expected:    []string{"pod-1"},
+		},
+		{
+			title:     "no matching pods",
+			name:      "test-svc",
+			namespace: "test-ns",
+			pods:      []corev1.Pod{},
+			selector: PodSelector{
+				Namespace: "test-ns",
+				Select: PodAttributes{Labels: map[string]string{
+					"app": "test",
+				}},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.title, func(t *testing.T) {
+			t.Parallel()
+
+			var objs []k8sruntime.Object
+			for p := range tc.pods {
+				objs = append(objs, &tc.pods[p])
+			}
+
+			client := fake.NewSimpleClientset(objs...)
+			k, _ := kubernetes.NewFakeKubernetes(client)
+
+			d, err := NewPodDisruptor(
+				context.TODO(),
+				k,
+				tc.selector,
+				PodDisruptorOptions{InjectTimeout: -1}, // Disable waiting for injected container to become Running.
+			)
+
+			if tc.expectError && err != nil {
+				return
+			}
+
+			if !tc.expectError && err != nil {
+				t.Errorf("unexpected error creating pod disruptor: %v", err)
+				return
+			}
+
+			if tc.expectError && err == nil {
+				t.Errorf("should had failed creating service disruptor")
+				return
+			}
+
+			targets, _ := d.Targets(context.TODO())
+			sort.Strings(targets)
+			if diff := cmp.Diff(targets, tc.expected); diff != "" {
+				t.Errorf("expected targets dot not match returned\n%s", diff)
+				return
+			}
+		})
+	}
+}
+
+func Test_PodSelectorString(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		selector PodSelector
+		expected string
+	}{
+		{
+			name:     "Empty selector",
+			expected: `all pods in ns "default"`,
+		},
+		{
+			name: "Only inclusions",
+			selector: PodSelector{
+				Namespace: "testns",
+				Select:    PodAttributes{map[string]string{"foo": "bar"}},
+			},
+			expected: `pods including(foo=bar) in ns "testns"`,
+		},
+		{
+			name: "Only exclusions",
+			selector: PodSelector{
+				Namespace: "testns",
+				Exclude:   PodAttributes{map[string]string{"foo": "bar"}},
+			},
+			expected: `pods excluding(foo=bar) in ns "testns"`,
+		},
+		{
+			name: "Both inclusions and exclusions",
+			selector: PodSelector{
+				Namespace: "testns",
+				Select:    PodAttributes{map[string]string{"foo": "bar"}},
+				Exclude:   PodAttributes{map[string]string{"boo": "baa"}},
+			},
+			expected: `pods including(foo=bar), excluding(boo=baa) in ns "testns"`,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			output := tc.selector.String()
+			if tc.expected != output {
+				t.Errorf("expected string does not match output string:\n%s\n%s", tc.expected, output)
 			}
 		})
 	}

--- a/pkg/disruptors/service_test.go
+++ b/pkg/disruptors/service_test.go
@@ -91,8 +91,7 @@ func Test_NewServiceDisruptor(t *testing.T) {
 				BuildAsPtr(),
 			pods:        []corev1.Pod{},
 			options:     ServiceDisruptorOptions{},
-			expectError: false,
-			expected:    []string{},
+			expectError: true,
 		},
 		{
 			title:       "service does not exist",


### PR DESCRIPTION
# Description

This PR adds logic to error out if a `PodDisruptor` or a `ServiceDisruptor` do not have any targets, which would make injection noop.

To avoid making the error too obscure, I've also added a bit of logic to render a `PodSelector` as a nicely formatted string.

As a side effect of making the `PodDisruptor` and `ServiceDisruptor` constructors return an error, the JS API tests (`github.com/grafana/xk6-disruptor/pkg/api`) would fail. To work around this, the setup code for the JS API tests now initizlize the K8s fake client with a service and a pod backing it.
Fixes #247.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make test`) and all tests pass.
- [x] I have run relevant e2e test locally (`make e2e-xxx` for `agent`, `disruptors`, `kubernetes` or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
