### PR TITLE
Implement fake client builder

### DIFF
--- a/pkg/testutils/kubernetes/builders/client.go
+++ b/pkg/testutils/kubernetes/builders/client.go
@@ -1,0 +1,212 @@
+package builders
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	// ObjectEventAll subscribe to all object events
+	ObjectEventAll ObjectEvent = "ALL"
+	// ObjectEventAdded subscribe to object creation events
+	ObjectEventAdded ObjectEvent = "ADDED"
+	// ObjectEventDeleted subscribe to object delete events
+	ObjectEventDeleted ObjectEvent = "DELETED"
+	// ObjectEventModified subscribe to object update events
+	ObjectEventModified ObjectEvent = "MODIFIED"
+)
+
+// ObjectEvent defines an event in an object
+type ObjectEvent string
+
+// PodObserver is a function that receives notifications of events on an Pod
+// and can update it by returning a non-nil value. In addition, the PodObserver
+// returns a boolean value indicating if it wants to keep receiving events or not.
+//
+// Note: PodObserver that subscribe to update events should implement a mechanism for
+// avoiding an update loop. They can for instance check the object is in a particular state
+// before updating. Additionally, they can unsubscribe from further updates.
+type PodObserver func(ObjectEvent, *corev1.Pod) (*corev1.Pod, bool, error)
+
+// ClientBuilder defines a fluent API for configuring a fake client for testing
+type ClientBuilder interface {
+	// returns an instance of a fake.Clientset.
+	Build() (*fake.Clientset, error)
+	// WithObjects initializes the client with the given runtime.Objects
+	WithObjects(objs ...runtime.Object) ClientBuilder
+	// WithNamespace initializes the client with the given namespace
+	WithNamespace(namespace string) ClientBuilder
+	// WithPods initializes the client with the given Pods
+	WithPods(pods ...*corev1.Pod) ClientBuilder
+	// WithServices initializes the client with the given Services
+	WithServices(pods ...*corev1.Service) ClientBuilder
+	// WithPodObserver adds a PodObserver that receives notifications of specific events
+	WithPodObserver(namespace string, event ObjectEvent, observer PodObserver) ClientBuilder
+	// WithContext sets a context allows cancelling object observers
+	WithContext(ctx context.Context) ClientBuilder
+	// WithErrorChannel sets a channel for reporting errors from observers
+	WithErrorChannel(chan error) ClientBuilder
+}
+
+// clientBuilder builds fake instances of Kubernetes.Interface
+type clientBuilder struct {
+	ctx       context.Context
+	client    *fake.Clientset
+	errors    []error
+	errCh     chan error
+	observers []func()
+	ready     sync.WaitGroup
+}
+
+// NewClientBuilder returns a ClientBuilder
+func NewClientBuilder() ClientBuilder {
+	return &clientBuilder{
+		ctx:    context.TODO(),
+		client: fake.NewSimpleClientset(),
+		errCh:  make(chan error),
+	}
+}
+
+func (b *clientBuilder) WithContext(ctx context.Context) ClientBuilder {
+	b.ctx = ctx
+	return b
+}
+
+func (b *clientBuilder) WithErrorChannel(errCh chan error) ClientBuilder {
+	b.errCh = errCh
+	return b
+}
+
+func (b *clientBuilder) WithObjects(objs ...runtime.Object) ClientBuilder {
+	for _, o := range objs {
+		err := b.client.Tracker().Add(o)
+		if err != nil {
+			b.errors = append(b.errors, err)
+			break
+		}
+	}
+	return b
+}
+
+func (b *clientBuilder) WithPods(pods ...*corev1.Pod) ClientBuilder {
+	for _, p := range pods {
+		_, err := b.client.CoreV1().Pods(p.Namespace).Create(context.TODO(), p, metav1.CreateOptions{})
+		if err != nil {
+			b.errors = append(b.errors, err)
+		}
+	}
+	return b
+}
+
+func (b *clientBuilder) WithNamespace(namespace string) ClientBuilder {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: namespace},
+	}
+	_, err := b.client.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+	if err != nil {
+		b.errors = append(b.errors, err)
+	}
+
+	return b
+}
+
+func (b *clientBuilder) WithServices(services ...*corev1.Service) ClientBuilder {
+	for _, s := range services {
+		_, err := b.client.CoreV1().Services(s.Namespace).Create(context.TODO(), s, metav1.CreateOptions{})
+		if err != nil {
+			b.errors = append(b.errors, err)
+		}
+	}
+	return b
+}
+
+//nolint:gocognit,nestif
+func (b *clientBuilder) WithPodObserver(namespace string, event ObjectEvent, observer PodObserver) ClientBuilder {
+	// goroutine that watches for events that match the observer's subscription
+	obsFunc := func() {
+		watcher, err := b.client.CoreV1().Pods(namespace).Watch(
+			context.TODO(),
+			metav1.ListOptions{},
+		)
+		if err != nil {
+			b.errCh <- fmt.Errorf("failed watching pods : %w", err)
+			return
+		}
+		defer watcher.Stop()
+
+		b.ready.Done()
+		for {
+			select {
+			case <-b.ctx.Done():
+				return
+			case watcherEvent := <-watcher.ResultChan():
+				if watcherEvent.Type == watch.Error {
+					b.errCh <- fmt.Errorf("error event received watching pods")
+					return
+				}
+				pod, isPod := watcherEvent.Object.(*corev1.Pod)
+
+				// if we receive an unexpected object, ignore
+				if !isPod {
+					continue
+				}
+				objectEvent := ObjectEvent(watcherEvent.Type)
+				if event == ObjectEventAll || objectEvent == event {
+					// call observer
+					updated, cont, err := observer(objectEvent, pod)
+					// if observer returns error notify and stop watching
+					if err != nil {
+						b.errCh <- fmt.Errorf("observer returned error: %w", err)
+						return
+					}
+
+					// if observer returns a non nul pod, update it
+					if updated != nil {
+						_, err := b.client.
+							CoreV1().
+							Pods(namespace).
+							Update(context.TODO(), updated, metav1.UpdateOptions{})
+						if err != nil {
+							b.errCh <- fmt.Errorf("failed updating pod %w", err)
+							return
+						}
+					}
+
+					// observer does not want to continue watching actions, stop watching
+					if !cont {
+						return
+					}
+				}
+			}
+		}
+	}
+
+	b.observers = append(b.observers, obsFunc)
+
+	return b
+}
+
+func (b *clientBuilder) Build() (*fake.Clientset, error) {
+	if len(b.errors) > 0 {
+		// TODO: use errors.Join when de code is updated to go >= 1.20
+		return nil, fmt.Errorf("errors building client %v", b.errors)
+	}
+
+	// start observers as goroutines
+	for _, observer := range b.observers {
+		b.ready.Add(1)
+		go observer()
+	}
+
+	// wait until all observers have started
+	b.ready.Wait()
+
+	return b.client, nil
+}

--- a/pkg/testutils/kubernetes/builders/client_test.go
+++ b/pkg/testutils/kubernetes/builders/client_test.go
@@ -1,0 +1,144 @@
+package builders
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func Test_WithPodObservers(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		test          string
+		event         ObjectEvent
+		setup         func(client *fake.Clientset) error
+		obsErr        error
+		obsBool       bool
+		expectErr     bool
+		expectTimeout bool
+	}{
+		{
+			test:          "Observe Pod Added",
+			event:         ObjectEventAdded,
+			obsErr:        nil,
+			obsBool:       false,
+			expectErr:     false,
+			expectTimeout: false,
+			setup: func(client *fake.Clientset) error {
+				pod := NewPodBuilder("pod1").WithNamespace("default").Build()
+				_, err := client.CoreV1().Pods("default").Create(context.TODO(), pod, metav1.CreateOptions{})
+				return err
+			},
+		},
+		{
+			test:          "Observe Pod Modified",
+			event:         ObjectEventModified,
+			obsErr:        nil,
+			obsBool:       false,
+			expectErr:     false,
+			expectTimeout: false,
+			setup: func(client *fake.Clientset) error {
+				pod := NewPodBuilder("pod1").WithNamespace("default").WithAnnotation("test.updated", "").Build()
+
+				pod, err := client.CoreV1().Pods("default").Create(context.TODO(), pod, metav1.CreateOptions{})
+				if err != nil {
+					return err
+				}
+
+				time.Sleep(time.Second)
+
+				pod.Annotations["test.updated"] = "true"
+				_, err = client.CoreV1().Pods("default").Update(context.TODO(), pod, metav1.UpdateOptions{})
+				return err
+			},
+		},
+		{
+			test:          "Observe Pod Modified timeout",
+			event:         ObjectEventModified,
+			obsErr:        nil,
+			obsBool:       false,
+			expectErr:     false,
+			expectTimeout: true,
+			setup: func(client *fake.Clientset) error {
+				pod := NewPodBuilder("pod1").WithNamespace("default").Build()
+				_, err := client.CoreV1().Pods("default").Create(context.TODO(), pod, metav1.CreateOptions{})
+				return err
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.test, func(t *testing.T) {
+			t.Parallel()
+
+			// test setup errors
+			errCh := make(chan error)
+			// observer termination signal
+			obsCh := make(chan bool)
+			// observer errors
+			obsErr := make(chan error)
+			// observer cancellation context
+			ctx, cancel := context.WithCancel(context.TODO())
+			defer cancel()
+
+			client, err := NewClientBuilder().
+				WithErrorChannel(obsErr).
+				WithContext(ctx).
+				WithPodObserver(
+					"default",
+					tc.event,
+					func(action ObjectEvent, pod *corev1.Pod) (*corev1.Pod, bool, error) {
+						if tc.event != ObjectEventAll && action != tc.event {
+							return nil, false, fmt.Errorf("invalid action. Expected: %s got %s", tc.event, action)
+						}
+
+						// signal observer has been executed
+						if tc.obsErr == nil {
+							obsCh <- true
+						}
+
+						return nil, tc.obsBool, tc.obsErr
+					},
+				).
+				Build()
+			if err != nil {
+				t.Errorf("failed to create client %v", err)
+				return
+			}
+
+			// execute the test setup in background
+			go func() {
+				e := tc.setup(client)
+				if e != nil {
+					errCh <- fmt.Errorf("test setup failed %w", e)
+				}
+			}()
+
+			timer := time.NewTimer(3 * time.Second)
+			select {
+			case <-obsCh:
+				// observer signaled execution without errors
+				return
+			case <-timer.C:
+				if !tc.expectTimeout {
+					t.Errorf("test timeout")
+				}
+				return
+			case err = <-errCh:
+				t.Errorf("unexpected error: %v", err)
+			case err = <-obsErr:
+				// observer signaled error, check if it is expected
+				if !tc.expectErr {
+					t.Errorf("failed with error: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/testutils/kubernetes/builders/pod.go
+++ b/pkg/testutils/kubernetes/builders/pod.go
@@ -13,6 +13,8 @@ type PodBuilder interface {
 	WithNamespace(namespace string) PodBuilder
 	// WithLabels sets the labels for the pod to be built
 	WithLabels(labels map[string]string) PodBuilder
+	// WithAnnotation adds an annotation
+	WithAnnotation(name string, value string) PodBuilder
 	// WithPhase sets the PodPhase for the pod to be built
 	WithPhase(status corev1.PodPhase) PodBuilder
 	// WithIP sets the IP address for the pod to be built
@@ -28,6 +30,7 @@ type podBuilder struct {
 	name        string
 	namespace   string
 	labels      map[string]string
+	annotations map[string]string
 	phase       corev1.PodPhase
 	ip          string
 	hostNetwork bool
@@ -38,7 +41,8 @@ type podBuilder struct {
 // and default attributes such as containers and namespace
 func NewPodBuilder(name string) PodBuilder {
 	return &podBuilder{
-		name: name,
+		name:        name,
+		annotations: map[string]string{},
 	}
 }
 
@@ -62,6 +66,11 @@ func (b *podBuilder) WithLabels(labels map[string]string) PodBuilder {
 	return b
 }
 
+func (b *podBuilder) WithAnnotation(name string, value string) PodBuilder {
+	b.annotations[name] = value
+	return b
+}
+
 func (b *podBuilder) WithHostNetwork(hostNetwork bool) PodBuilder {
 	b.hostNetwork = hostNetwork
 	return b
@@ -79,9 +88,10 @@ func (b *podBuilder) Build() *corev1.Pod {
 			Kind:       "Pod",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      b.name,
-			Namespace: b.namespace,
-			Labels:    b.labels,
+			Name:        b.name,
+			Namespace:   b.namespace,
+			Labels:      b.labels,
+			Annotations: b.annotations,
 		},
 		Spec: corev1.PodSpec{
 			Containers:          b.containers,


### PR DESCRIPTION
# Description

Implements a builder for fake clients that facilitates common tasks. 

In particular, it allows attaching observers for object events (added, modified, deleted) that can react to those events and eventually update the objects.  This simplifies tests that require reacting to events (for example, changing the status of a container once it is created) by:
- eliminating complex boilerplate code
- eliminating the need of using goroutines for handling events concurrently with the test logic
- sound and robust error handling 

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works.   
- [X] I have run linter locally (`make lint`) and all checks pass.
- [X] I have run tests locally (`make test`) and all tests pass.
- [ ] I have run relevant e2e test locally (`make e2e-xxx` for `agent`, `disruptors`, `kubernetes` or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
