### PR TITLE
ci: run ci for all PRs, not only those targeting main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,7 @@ on:
       - main
     tags:
       - v*
-  pull_request:
-      branches:
-      - main
+  pull_request: {}
 
 jobs:
   build-with-xk6:


### PR DESCRIPTION
# Description

Sometimes it is useful to stack PRs to make reviewing them easier, specially as Github is kind enough to automatically repoint them to `main` when the base PR gets merged.

Currently, PRs not pointing to main do not get tested. This PR proposes changing that to allow for this kind of workflow.

 
