### PR TITLE
Remove service proxy test helper

### DIFF
--- a/pkg/kubernetes/helpers/fake.go
+++ b/pkg/kubernetes/helpers/fake.go
@@ -1,9 +1,6 @@
 package helpers
 
 import (
-	"io"
-	"net/http"
-	"strings"
 	"sync"
 
 	"k8s.io/client-go/kubernetes"
@@ -103,36 +100,4 @@ func NewFakeServiceHelper(
 		h,
 		executor,
 	}
-}
-
-// FakeHTTPClient implement a fake HTTPClient that returns a fixed response.
-// When invoked, it records the request it received
-type FakeHTTPClient struct {
-	Request  *http.Request
-	Response *http.Response
-	Err      error
-}
-
-// newFakeHTTPClient creates a FakeHTTPClient that returns a fixed response from a status and an content body
-func newFakeHTTPClient(status int, body []byte) *FakeHTTPClient {
-	response := &http.Response{
-		Proto:         "HTTP/1.1",
-		ProtoMajor:    1,
-		ProtoMinor:    1,
-		StatusCode:    status,
-		Status:        http.StatusText(status),
-		Body:          io.NopCloser(strings.NewReader(string(body))),
-		ContentLength: int64(len(body)),
-	}
-
-	return &FakeHTTPClient{
-		Response: response,
-		Err:      nil,
-	}
-}
-
-// Do implements HTTPClient's Do method
-func (f *FakeHTTPClient) Do(req *http.Request) (*http.Response, error) {
-	f.Request = req
-	return f.Response, f.Err
 }

--- a/pkg/kubernetes/helpers/services.go
+++ b/pkg/kubernetes/helpers/services.go
@@ -3,7 +3,6 @@ package helpers
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"time"
 
 	"github.com/grafana/xk6-disruptor/pkg/utils"
@@ -21,8 +20,6 @@ type ServiceHelper interface {
 	WaitServiceReady(ctx context.Context, service string, timeout time.Duration) error
 	// WaitIngressReady waits for the given service to have a load balancer address assigned
 	WaitIngressReady(ctx context.Context, ingress string, timeout time.Duration) error
-	// GetServiceProxy returns a client for making HTTP requests to the service using api server's proxy
-	GetServiceProxy(name string, svcPort int) (ServiceClient, error)
 	// GetTargets returns the list of pods that match the service selector criteria
 	GetTargets(ctx context.Context, service string) ([]corev1.Pod, error)
 }
@@ -94,70 +91,4 @@ func (h *serviceHelper) GetTargets(ctx context.Context, name string) ([]corev1.P
 	)
 
 	return pods.Items, err
-}
-
-// ServiceClient is the minimal interface for executing HTTP requests
-// Offers an interface similar to http.Client but only the Do method is supported
-// It is used primarily to allow mocking the client in unit tests
-type ServiceClient interface {
-	// Do executes the request to the service and returns the response
-	// From the request only the URL path method, headers and body are considered
-	Do(request *http.Request) (*http.Response, error)
-}
-
-// ServiceProxy implements the HTTPClient interface for making HTTP request to a service
-type ServiceProxy struct {
-	service   string
-	namespace string
-	port      int
-	baseURL   string
-	client    ServiceClient
-}
-
-// newServiceProxy creates a ServiceProxy
-func newServiceProxy(
-	httpClient ServiceClient,
-	host string,
-	namespace string,
-	service string,
-	port int,
-) *ServiceProxy {
-	// build url to the service proxy
-	baseURL := fmt.Sprintf("%s/api/v1/namespaces/%s/services/%s:%d/proxy", host, namespace, service, port)
-
-	return &ServiceProxy{
-		client:    httpClient,
-		service:   service,
-		namespace: namespace,
-		baseURL:   baseURL,
-		port:      port,
-	}
-}
-
-func (h *serviceHelper) GetServiceProxy(service string, port int) (ServiceClient, error) {
-	httpClient, err := rest.HTTPClientFor(h.config)
-	if err != nil {
-		return nil, err
-	}
-
-	return newServiceProxy(
-		httpClient,
-		h.config.Host,
-		h.namespace,
-		service,
-		port,
-	), nil
-}
-
-// Do implements the Do method from the ServiceClient interface
-func (c *ServiceProxy) Do(request *http.Request) (*http.Response, error) {
-	serviceURL := c.baseURL + request.URL.Path
-	serviceRequest, err := http.NewRequest(request.Method, serviceURL, request.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	serviceRequest.Header = request.Header
-
-	return c.client.Do(serviceRequest)
 }

--- a/pkg/kubernetes/helpers/services_test.go
+++ b/pkg/kubernetes/helpers/services_test.go
@@ -1,9 +1,7 @@
 package helpers
 
 import (
-	"bytes"
 	"context"
-	"net/http"
 	"testing"
 	"time"
 
@@ -256,90 +254,6 @@ func Test_WaitIngressReady(t *testing.T) {
 			}
 			// error expected and returned, it is ok
 			if tc.expectError && err != nil {
-				return
-			}
-		})
-	}
-}
-
-func Test_ServiceClient(t *testing.T) {
-	t.Parallel()
-
-	testCases := []struct {
-		name        string
-		host        string
-		service     string
-		port        int
-		namespace   string
-		method      string
-		path        string
-		reqBody     []byte
-		headers     map[string]string
-		respBody    []byte
-		respStatus  int
-		expectError bool
-		expectURL   string
-	}{
-		{
-			name:        "simple get request",
-			host:        "http://localhost:8001",
-			service:     "my-service",
-			port:        80,
-			namespace:   "default",
-			method:      "GET",
-			path:        "/path/to/request",
-			reqBody:     []byte{},
-			headers:     map[string]string{},
-			respBody:    []byte{},
-			respStatus:  200,
-			expectError: false,
-			expectURL:   "http://localhost:8001/api/v1/namespaces/default/services/my-service:80/proxy/path/to/request",
-		},
-	}
-
-	for _, tc := range testCases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			testRequest, err := http.NewRequest(tc.method, tc.path, bytes.NewReader(tc.reqBody))
-			if err != nil {
-				t.Errorf("failed creating test request %v", err)
-				return
-			}
-
-			fakeClient := newFakeHTTPClient(tc.respStatus, tc.respBody)
-			serviceClient := newServiceProxy(
-				fakeClient,
-				tc.host,
-				tc.namespace,
-				tc.service,
-				tc.port,
-			)
-
-			_, err = serviceClient.Do(testRequest)
-
-			if !tc.expectError && err != nil {
-				t.Errorf("failed: %v", err)
-				return
-			}
-
-			if tc.expectError && err == nil {
-				t.Errorf("should have failed")
-				return
-			}
-
-			if tc.expectError && err != nil {
-				return
-			}
-
-			if fakeClient.Request.URL.String() != tc.expectURL {
-				t.Errorf("invalid request url. Expected: %s received: %s", tc.expectURL, fakeClient.Request.URL.String())
-				return
-			}
-
-			if fakeClient.Request.Method != tc.method {
-				t.Errorf("invalid request method. Expected: %s received: %s", tc.method, fakeClient.Request.Method)
 				return
 			}
 		})


### PR DESCRIPTION
# Description

The service proxy test helper was introduced to facilitate access to services in e2e tests without having to expose them in the cluster. Since https://github.com/grafana/xk6-disruptor/pull/160 e2e tests use ingresses for accessing services, making the service proxy redundant. 

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [X] I have run linter locally (`make lint`) and all checks pass.
- [X] I have run tests locally (`make test`) and all tests pass.
- [X] I have run relevant e2e test locally (`make e2e-xxx` for `agent`, `disruptors`, `kubernetes` or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
