### PR TITLE
Simplify kubernetes fake

### DIFF
--- a/pkg/disruptors/controller_test.go
+++ b/pkg/disruptors/controller_test.go
@@ -78,7 +78,7 @@ func Test_InjectAgent(t *testing.T) {
 
 			client := fake.NewSimpleClientset(objs...)
 			executor := helpers.NewFakePodCommandExecutor()
-			helper := helpers.NewFakePodHelper(client, tc.namespace, executor)
+			helper := helpers.NewPodHelper(client, executor, tc.namespace)
 			controller := NewAgentController(
 				context.TODO(),
 				helper,
@@ -182,7 +182,7 @@ func Test_ExecCommand(t *testing.T) {
 			}
 			client := fake.NewSimpleClientset(objs...)
 			executor := helpers.NewFakePodCommandExecutor()
-			helper := helpers.NewFakePodHelper(client, tc.namespace, executor)
+			helper := helpers.NewPodHelper(client, executor, tc.namespace)
 			controller := NewAgentController(
 				context.TODO(),
 				helper,
@@ -215,6 +215,7 @@ func Test_ExecCommand(t *testing.T) {
 			for _, p := range targets {
 				expected = append(expected, helpers.Command{
 					Pod:       p.Name,
+					Namespace: p.Namespace,
 					Container: "xk6-agent",
 					Command:   tc.command,
 					Stdin:     []byte{},

--- a/pkg/kubernetes/fake.go
+++ b/pkg/kubernetes/fake.go
@@ -27,19 +27,18 @@ func NewFakeKubernetes(clientset *fake.Clientset) (*FakeKubernetes, error) {
 
 // PodHelper returns a PodHelper for the given namespace
 func (f *FakeKubernetes) PodHelper(namespace string) helpers.PodHelper {
-	return helpers.NewFakePodHelper(
+	return helpers.NewPodHelper(
 		f.client,
-		namespace,
 		f.executor,
+		namespace,
 	)
 }
 
 // ServiceHelper returns a ServiceHelper for the given namespace
 func (f *FakeKubernetes) ServiceHelper(namespace string) helpers.ServiceHelper {
-	return helpers.NewFakeServiceHelper(
+	return helpers.NewServiceHelper(
 		f.client,
 		namespace,
-		f.executor,
 	)
 }
 

--- a/pkg/kubernetes/helpers/executor.go
+++ b/pkg/kubernetes/helpers/executor.go
@@ -1,0 +1,69 @@
+package helpers
+
+import (
+	"bytes"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+// PodCommandExecutor defines a method for executing commands in a target Pod
+type PodCommandExecutor interface {
+	// Exec executes a non-interactive command described in options and returns the stdout and stderr outputs
+	Exec(pod string, namespace string, container string, command []string, stdin []byte) ([]byte, []byte, error)
+}
+
+type restExecutor struct {
+	client rest.Interface
+	config *rest.Config
+}
+
+// NewRestExecutor returns a PodCommandExecutor that executes command using rest client with the
+// given rest configuration
+func NewRestExecutor(client rest.Interface, config *rest.Config) PodCommandExecutor {
+	return &restExecutor{
+		client: client,
+		config: config,
+	}
+}
+
+func (h *restExecutor) Exec(
+	pod string,
+	namespace string,
+	container string,
+	command []string,
+	stdin []byte,
+) ([]byte, []byte, error) {
+	req := h.client.
+		Post().
+		Namespace(namespace).
+		Resource("pods").
+		Name(pod).
+		SubResource("exec").
+		VersionedParams(&corev1.PodExecOptions{
+			Container: container,
+			Command:   command,
+			Stdin:     true,
+			Stdout:    true,
+			Stderr:    true,
+			TTY:       false,
+		}, scheme.ParameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(h.config, "POST", req.URL())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var stdout, stderr bytes.Buffer
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdin:  bytes.NewReader(stdin),
+		Stdout: &stdout,
+		Stderr: &stderr,
+		Tty:    false,
+	})
+
+	return stdout.Bytes(), stderr.Bytes(), err
+}

--- a/pkg/kubernetes/helpers/services.go
+++ b/pkg/kubernetes/helpers/services.go
@@ -11,7 +11,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
 )
 
 // ServiceHelper implements functions for dealing with services
@@ -26,16 +25,14 @@ type ServiceHelper interface {
 
 // helpers struct holds the data required by the helpers
 type serviceHelper struct {
-	config    *rest.Config
 	client    kubernetes.Interface
 	namespace string
 }
 
 // NewServiceHelper returns a ServiceHelper
-func NewServiceHelper(client kubernetes.Interface, config *rest.Config, namespace string) ServiceHelper {
+func NewServiceHelper(client kubernetes.Interface, namespace string) ServiceHelper {
 	return &serviceHelper{
 		client:    client,
-		config:    config,
 		namespace: namespace,
 	}
 }

--- a/pkg/kubernetes/helpers/services_test.go
+++ b/pkg/kubernetes/helpers/services_test.go
@@ -143,7 +143,7 @@ func Test_WaitServiceReady(t *testing.T) {
 				}
 			}(tc)
 
-			h := NewServiceHelper(client, nil, "default")
+			h := NewServiceHelper(client, "default")
 
 			err := h.WaitServiceReady(context.TODO(), "service", tc.timeout)
 			if !tc.expectError && err != nil {
@@ -241,7 +241,7 @@ func Test_WaitIngressReady(t *testing.T) {
 				}
 			}(tc)
 
-			h := NewServiceHelper(client, nil, "default")
+			h := NewServiceHelper(client, "default")
 
 			err := h.WaitIngressReady(context.TODO(), "ingress", tc.timeout)
 			if !tc.expectError && err != nil {
@@ -345,7 +345,7 @@ func Test_Targets(t *testing.T) {
 				}
 			}
 
-			helper := NewServiceHelper(client, nil, tc.namespace)
+			helper := NewServiceHelper(client, tc.namespace)
 			targets, err := helper.GetTargets(context.TODO(), tc.serviceName)
 			if !tc.expectError && err != nil {
 				t.Errorf("failed: %v", err)

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -111,16 +111,16 @@ func checkK8sVersion(config *rest.Config) error {
 func (k *k8s) ServiceHelper(namespace string) helpers.ServiceHelper {
 	return helpers.NewServiceHelper(
 		k.Interface,
-		k.config,
 		namespace,
 	)
 }
 
 // PodHelper returns a PodHelper for the given namespace
 func (k *k8s) PodHelper(namespace string) helpers.PodHelper {
+	executor := helpers.NewRestExecutor(k.CoreV1().RESTClient(), k.config)
 	return helpers.NewPodHelper(
-		k.Interface,
-		k.config,
+		k,
+		executor,
 		namespace,
 	)
 }


### PR DESCRIPTION
# Description

Refactor kubernetes package to simplify the creation of fake implementations for testing

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [X] I have run linter locally (`make lint`) and all checks pass.
- [X] I have run tests locally (`make test`) and all tests pass.
- [X] I have run relevant e2e test locally (`make e2e-xxx` for `agent`, `disruptors`, `kubernetes` or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
