### PR TITLE
Revert revert of refactor proxy for simpler error handling (#271)

### DIFF
--- a/pkg/agent/protocol/http/proxy.go
+++ b/pkg/agent/protocol/http/proxy.go
@@ -109,7 +109,7 @@ func (h *httpHandler) forward(rw http.ResponseWriter, req *http.Request, delay t
 	upstreamReq.URL.Scheme = h.upstreamURL.Scheme
 	upstreamReq.RequestURI = "" // It is an error to set this field in an HTTP client request.
 
-	response, err := h.client.Do(req)
+	response, err := h.client.Do(upstreamReq)
 	<-timer
 	if err != nil {
 		rw.WriteHeader(http.StatusBadGateway)

--- a/pkg/testutils/e2e/checks/checks.go
+++ b/pkg/testutils/e2e/checks/checks.go
@@ -59,7 +59,7 @@ type GrpcCheck struct {
 }
 
 // Verify verifies a HTTPCheck
-func (c HTTPCheck) Verify(_ kubernetes.Kubernetes, ingress string, _ string) error {
+func (c HTTPCheck) Verify(_ kubernetes.Kubernetes, ingress string, namespace string) error {
 	time.Sleep(c.Delay)
 
 	url := fmt.Sprintf("http://%s", ingress)
@@ -67,7 +67,7 @@ func (c HTTPCheck) Verify(_ kubernetes.Kubernetes, ingress string, _ string) err
 	if err != nil {
 		return err
 	}
-	request.Host = c.Service
+	request.Host = fmt.Sprintf("%s.%s", c.Service, namespace)
 
 	resp, err := http.DefaultClient.Do(request)
 	if err != nil {
@@ -85,14 +85,14 @@ func (c HTTPCheck) Verify(_ kubernetes.Kubernetes, ingress string, _ string) err
 }
 
 // Verify verifies a GrpcServiceCheck
-func (c GrpcCheck) Verify(_ kubernetes.Kubernetes, ingress string, _ string) error {
+func (c GrpcCheck) Verify(_ kubernetes.Kubernetes, ingress string, namespace string) error {
 	time.Sleep(c.Delay)
 
 	client, err := dynamic.NewClientWithDialOptions(
 		ingress,
 		c.GrpcService,
 		grpc.WithInsecure(),
-		grpc.WithAuthority(c.Service),
+		grpc.WithAuthority(fmt.Sprintf("%s.%s", c.Service, namespace)),
 	)
 	if err != nil {
 		return fmt.Errorf("error creating client for service %s: %w", c.Service, err)

--- a/pkg/testutils/kubernetes/builders/ingress.go
+++ b/pkg/testutils/kubernetes/builders/ingress.go
@@ -1,6 +1,8 @@
 package builders
 
 import (
+	"fmt"
+
 	networking "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -92,7 +94,7 @@ func (b *ingressBuilder) Build() *networking.Ingress {
 			IngressClassName: b.class,
 			Rules: []networking.IngressRule{
 				{
-					Host: b.host,
+					Host: fmt.Sprintf("%s.%s", b.host, b.namespace),
 					IngressRuleValue: networking.IngressRuleValue{
 						HTTP: &networking.HTTPIngressRuleValue{
 							Paths: []networking.HTTPIngressPath{


### PR DESCRIPTION
# Description

This PR brings back #271 fixing a bug that caused all requests that were supposed to be forwarded upstream to return a 502 error.

Additionaly, it adds an E2E test covering this use case.

Fixes #292 

# Checklist:

- [ ] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works.   
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make test`) and all tests pass.
- [x] I have run relevant e2e test locally (`make e2e-xxx` for `agent`, `disruptors`, `kubernetes` or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
