### PR TITLE
Simplify Kubernetes test helpers

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,7 +29,6 @@ issues:
         - dupl
         - funlen
         - gocognit
-        - lll
         - bodyclose
         - maintidx
         - unparam

--- a/disruptor_test.go
+++ b/disruptor_test.go
@@ -17,7 +17,6 @@ import (
 	"go.k6.io/k6/lib/testutils"
 	"go.k6.io/k6/metrics"
 
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
@@ -128,7 +127,7 @@ func Test_ServiceDisruptor(t *testing.T) {
 		WithSelector(labels).
 		Build()
 	endpoints := builders.NewEndPointsBuilder("app-service").
-		WithSubset([]corev1.EndpointPort{{Name: "http", Port: 80}}, []string{"app-pod"}).
+		WithSubset("http", 80, []string{"app-pod"}).
 		Build()
 
 	client := fake.NewSimpleClientset(pod, svc, endpoints)

--- a/disruptor_test.go
+++ b/disruptor_test.go
@@ -85,10 +85,8 @@ func Test_PodDisruptor(t *testing.T) {
 	t.Parallel()
 
 	pod := builders.NewPodBuilder("pod-with-app-label").
-		WithNamespace("default").
-		WithLabels(map[string]string{
-			"app": "test",
-		}).
+		WithDefaultNamespace().
+		WithLabel("app", "test").
 		Build()
 	client := fake.NewSimpleClientset(pod)
 	k8s, _ := kubernetes.NewFakeKubernetes(client)
@@ -122,7 +120,7 @@ func Test_ServiceDisruptor(t *testing.T) {
 		"app": "test",
 	}
 	pod := builders.NewPodBuilder("app-pod").
-		WithNamespace("default").
+		WithDefaultNamespace().
 		WithLabels(labels).
 		Build()
 	svc := builders.NewServiceBuilder("app-service").

--- a/disruptor_test.go
+++ b/disruptor_test.go
@@ -126,11 +126,8 @@ func Test_ServiceDisruptor(t *testing.T) {
 		WithNamespace("default").
 		WithSelector(labels).
 		Build()
-	endpoints := builders.NewEndPointsBuilder("app-service").
-		WithSubset("http", 80, []string{"app-pod"}).
-		Build()
 
-	client := fake.NewSimpleClientset(&pod, &svc, &endpoints)
+	client := fake.NewSimpleClientset(&pod, &svc)
 	k8s, _ := kubernetes.NewFakeKubernetes(client)
 	vu := testVU()
 	err := setTestModule(k8s, vu)

--- a/disruptor_test.go
+++ b/disruptor_test.go
@@ -87,7 +87,7 @@ func Test_PodDisruptor(t *testing.T) {
 		WithDefaultNamespace().
 		WithLabel("app", "test").
 		Build()
-	client := fake.NewSimpleClientset(pod)
+	client := fake.NewSimpleClientset(&pod)
 	k8s, _ := kubernetes.NewFakeKubernetes(client)
 	vu := testVU()
 	err := setTestModule(k8s, vu)
@@ -130,7 +130,7 @@ func Test_ServiceDisruptor(t *testing.T) {
 		WithSubset("http", 80, []string{"app-pod"}).
 		Build()
 
-	client := fake.NewSimpleClientset(pod, svc, endpoints)
+	client := fake.NewSimpleClientset(&pod, &svc, &endpoints)
 	k8s, _ := kubernetes.NewFakeKubernetes(client)
 	vu := testVU()
 	err := setTestModule(k8s, vu)

--- a/e2e/agent/agent_e2e_test.go
+++ b/e2e/agent/agent_e2e_test.go
@@ -114,8 +114,8 @@ func buildHttpbinPodWithDisruptorAgent(cmd []string) *corev1.Pod {
 
 	return builders.NewPodBuilder("httpbin").
 		WithLabel("app", "httpbin").
-		WithContainer(*httpbin).
-		WithContainer(*agent).
+		WithContainer(httpbin).
+		WithContainer(agent).
 		Build()
 }
 
@@ -135,8 +135,8 @@ func buildGrpcbinPodWithDisruptorAgent(cmd []string) *corev1.Pod {
 
 	return builders.NewPodBuilder("grpcbin").
 		WithLabel("app", "grpcbin").
-		WithContainer(*grpcbin).
-		WithContainer(*agent).
+		WithContainer(grpcbin).
+		WithContainer(agent).
 		Build()
 }
 
@@ -151,7 +151,7 @@ func buildDisruptorAgentPod(cmd []string) *corev1.Pod {
 
 	return builders.NewPodBuilder("xk6-disruptor").
 		WithLabel("app", "xk6-disruptor").
-		WithContainer(*agent).
+		WithContainer(agent).
 		Build()
 }
 

--- a/e2e/agent/agent_e2e_test.go
+++ b/e2e/agent/agent_e2e_test.go
@@ -99,7 +99,7 @@ var (
 )
 
 // deploy pod with [httpbin] and the xk6-disruptor as sidekick container
-func buildHttpbinPodWithDisruptorAgent(cmd []string) *corev1.Pod {
+func buildHttpbinPodWithDisruptorAgent(cmd []string) corev1.Pod {
 	httpbin := builders.NewContainerBuilder("httpbin").
 		WithImage("kennethreitz/httpbin").
 		WithPort("http", 80).
@@ -120,7 +120,7 @@ func buildHttpbinPodWithDisruptorAgent(cmd []string) *corev1.Pod {
 }
 
 // deploy pod with grpcbin and the xk6-disruptor as sidekick container
-func buildGrpcbinPodWithDisruptorAgent(cmd []string) *corev1.Pod {
+func buildGrpcbinPodWithDisruptorAgent(cmd []string) corev1.Pod {
 	grpcbin := builders.NewContainerBuilder("grpcbin").
 		WithImage("moul/grpcbin").
 		WithPort("grpc", 9000).
@@ -141,7 +141,7 @@ func buildGrpcbinPodWithDisruptorAgent(cmd []string) *corev1.Pod {
 }
 
 // deploy pod with the xk6-disruptor
-func buildDisruptorAgentPod(cmd []string) *corev1.Pod {
+func buildDisruptorAgentPod(cmd []string) corev1.Pod {
 	agent := builders.NewContainerBuilder("xk6-disruptor-agent").
 		WithImage("ghcr.io/grafana/xk6-disruptor-agent").
 		WithPort("http", 80).
@@ -156,7 +156,7 @@ func buildDisruptorAgentPod(cmd []string) *corev1.Pod {
 }
 
 // builDisruptorService returns a Service definition that exposes httpbin pods
-func builDisruptorService() *corev1.Service {
+func builDisruptorService() corev1.Service {
 	return builders.NewServiceBuilder("xk6-disruptor").
 		WithSelectorLabel("app", "xk6-disruptor").
 		WithPort("http", 80, intstr.FromString("http")).
@@ -186,8 +186,8 @@ func Test_Agent(t *testing.T) {
 
 		testCases := []struct {
 			title string
-			pod   *corev1.Pod
-			svc   *corev1.Service
+			pod   corev1.Pod
+			svc   corev1.Service
 			port  int
 			check checks.Check
 		}{

--- a/e2e/agent/agent_e2e_test.go
+++ b/e2e/agent/agent_e2e_test.go
@@ -113,11 +113,7 @@ func buildHttpbinPodWithDisruptorAgent(cmd []string) *corev1.Pod {
 		Build()
 
 	return builders.NewPodBuilder("httpbin").
-		WithLabels(
-			map[string]string{
-				"app": "httpbin",
-			},
-		).
+		WithLabel("app", "httpbin").
 		WithContainer(*httpbin).
 		WithContainer(*agent).
 		Build()
@@ -138,11 +134,7 @@ func buildGrpcbinPodWithDisruptorAgent(cmd []string) *corev1.Pod {
 		Build()
 
 	return builders.NewPodBuilder("grpcbin").
-		WithLabels(
-			map[string]string{
-				"app": "grpcbin",
-			},
-		).
+		WithLabel("app", "grpcbin").
 		WithContainer(*grpcbin).
 		WithContainer(*agent).
 		Build()
@@ -158,11 +150,7 @@ func buildDisruptorAgentPod(cmd []string) *corev1.Pod {
 		Build()
 
 	return builders.NewPodBuilder("xk6-disruptor").
-		WithLabels(
-			map[string]string{
-				"app": "xk6-disruptor",
-			},
-		).
+		WithLabel("app", "xk6-disruptor").
 		WithContainer(*agent).
 		Build()
 }

--- a/e2e/agent/agent_e2e_test.go
+++ b/e2e/agent/agent_e2e_test.go
@@ -158,20 +158,8 @@ func buildDisruptorAgentPod(cmd []string) *corev1.Pod {
 // builDisruptorService returns a Service definition that exposes httpbin pods
 func builDisruptorService() *corev1.Service {
 	return builders.NewServiceBuilder("xk6-disruptor").
-		WithSelector(
-			map[string]string{
-				"app": "xk6-disruptor",
-			},
-		).
-		WithPorts(
-			[]corev1.ServicePort{
-				{
-					Name:       "http",
-					Port:       80,
-					TargetPort: intstr.FromString("http"),
-				},
-			},
-		).
+		WithSelectorLabel("app", "xk6-disruptor").
+		WithPort("http", 80, intstr.FromString("http")).
 		Build()
 }
 

--- a/e2e/cluster/cluster_e2e_test.go
+++ b/e2e/cluster/cluster_e2e_test.go
@@ -87,7 +87,7 @@ func buildBusyboxPod() *corev1.Pod {
 		Build()
 
 	return builders.NewPodBuilder("busybox").
-		WithContainer(*busybox).
+		WithContainer(busybox).
 		Build()
 }
 

--- a/e2e/disruptors/pod_e2e_test.go
+++ b/e2e/disruptors/pod_e2e_test.go
@@ -45,8 +45,8 @@ func Test_PodDisruptor(t *testing.T) {
 
 		testCases := []struct {
 			title    string
-			pod      *corev1.Pod
-			service  *corev1.Service
+			pod      corev1.Pod
+			service  corev1.Service
 			port     int
 			injector func(d disruptors.PodDisruptor) error
 			check    checks.Check

--- a/e2e/disruptors/service_e2e_test.go
+++ b/e2e/disruptors/service_e2e_test.go
@@ -44,8 +44,8 @@ func Test_ServiceDisruptor(t *testing.T) {
 
 		testCases := []struct {
 			title    string
-			pod      *corev1.Pod
-			service  *corev1.Service
+			pod      corev1.Pod
+			service  corev1.Service
 			port     int
 			injector func(d disruptors.ServiceDisruptor) error
 			check    checks.Check

--- a/e2e/kubectl/kubectl_e2e_test.go
+++ b/e2e/kubectl/kubectl_e2e_test.go
@@ -48,7 +48,7 @@ func Test_Kubectl(t *testing.T) {
 		// Deploy nginx
 		nginx := builders.NewPodBuilder("nginx").
 			WithContainer(
-				*builders.NewContainerBuilder("nginx").
+				builders.NewContainerBuilder("nginx").
 				WithImage("nginx").
 				WithPort("http", 80).
 				Build(),

--- a/e2e/kubernetes/kubernetes_e2e_test.go
+++ b/e2e/kubernetes/kubernetes_e2e_test.go
@@ -47,9 +47,10 @@ func Test_Kubernetes(t *testing.T) {
 		}
 
 		// Deploy nginx
+		nginx := fixtures.BuildNginxPod()
 		_, err = k8s.Client().CoreV1().Pods(namespace).Create(
 			context.TODO(),
-			fixtures.BuildNginxPod(),
+			&nginx,
 			metav1.CreateOptions{},
 		)
 		if err != nil {
@@ -80,9 +81,10 @@ func Test_Kubernetes(t *testing.T) {
 		// Deploy nginx and expose it as a service. Intentionally not using e2e fixures
 		// because these functions rely on WaitPodRunnin and WaitServiceReady which we
 		// are testing here.
+		nginxPod := fixtures.BuildNginxPod()
 		_, err = k8s.Client().CoreV1().Pods(namespace).Create(
 			context.TODO(),
-			fixtures.BuildNginxPod(),
+			&nginxPod,
 			metav1.CreateOptions{},
 		)
 		if err != nil {
@@ -90,9 +92,10 @@ func Test_Kubernetes(t *testing.T) {
 			return
 		}
 
+		nginxSvc := fixtures.BuildNginxService()
 		_, err = k8s.Client().CoreV1().Services(namespace).Create(
 			context.TODO(),
-			fixtures.BuildNginxService(),
+			&nginxSvc,
 			metav1.CreateOptions{},
 		)
 		if err != nil {

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -506,8 +506,8 @@ func Test_ServiceDisruptorConstructor(t *testing.T) {
 			svc := builders.NewServiceBuilder("service").WithSelector(labels).Build()
 			ep := builders.NewEndPointsBuilder("service").Build()
 
-			_, _ = env.client.CoreV1().Services("default").Create(context.TODO(), svc, v1.CreateOptions{})
-			_, _ = env.client.CoreV1().Endpoints("default").Create(context.TODO(), ep, v1.CreateOptions{})
+			_, _ = env.client.CoreV1().Services("default").Create(context.TODO(), &svc, v1.CreateOptions{})
+			_, _ = env.client.CoreV1().Endpoints("default").Create(context.TODO(), &ep, v1.CreateOptions{})
 
 			_, err = env.rt.RunString(tc.script)
 

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -504,10 +504,7 @@ func Test_ServiceDisruptorConstructor(t *testing.T) {
 				"app": "test",
 			}
 			svc := builders.NewServiceBuilder("service").WithSelector(labels).Build()
-			ep := builders.NewEndPointsBuilder("service").Build()
-
 			_, _ = env.client.CoreV1().Services("default").Create(context.TODO(), &svc, v1.CreateOptions{})
-			_, _ = env.client.CoreV1().Endpoints("default").Create(context.TODO(), &ep, v1.CreateOptions{})
 
 			_, err = env.rt.RunString(tc.script)
 

--- a/pkg/disruptors/pod_test.go
+++ b/pkg/disruptors/pod_test.go
@@ -75,7 +75,7 @@ func buildPodWithPort(name string, portName string, port int32) *corev1.Pod {
 
 	pod := builders.NewPodBuilder(name).
 		WithNamespace("test-ns").
-		WithContainer(*container).
+		WithContainer(container).
 		WithIP("192.0.2.6").
 		Build()
 
@@ -241,7 +241,7 @@ func Test_PodHTTPFaultInjection(t *testing.T) {
 				WithNamespace("test-ns").
 				WithLabel("app", "myapp").
 				WithContainer(
-					*builders.NewContainerBuilder("noip").
+					builders.NewContainerBuilder("noip").
 						WithPort("http", 80).
 						Build(),
 				).
@@ -270,7 +270,7 @@ func Test_PodHTTPFaultInjection(t *testing.T) {
 				WithHostNetwork(true).
 				WithIP("192.0.2.6").
 				WithContainer(
-					*builders.NewContainerBuilder("myapp").
+					builders.NewContainerBuilder("myapp").
 						WithPort("http", 80).
 						Build(),
 				).

--- a/pkg/disruptors/pod_test.go
+++ b/pkg/disruptors/pod_test.go
@@ -68,7 +68,7 @@ func newPodDisruptorForTesting(controller AgentController, podHelper helpers.Pod
 	}
 }
 
-func buildPodWithPort(name string, portName string, port int32) *corev1.Pod {
+func buildPodWithPort(name string, portName string, port int32) corev1.Pod {
 	container := builders.NewContainerBuilder(name).
 		WithPort(portName, port).
 		Build()
@@ -88,7 +88,7 @@ func Test_PodHTTPFaultInjection(t *testing.T) {
 	testCases := []struct {
 		title        string
 		selector     PodSelector
-		target       *corev1.Pod
+		target       corev1.Pod
 		expectedCmds []string
 		expectError  bool
 		cmdError     error
@@ -294,11 +294,11 @@ func Test_PodHTTPFaultInjection(t *testing.T) {
 
 			controller := &fakeAgentController{
 				namespace: tc.selector.Namespace,
-				targets:   []corev1.Pod{*tc.target},
+				targets:   []corev1.Pod{tc.target},
 				executor:  executor,
 			}
 
-			client := fake.NewSimpleClientset(tc.target)
+			client := fake.NewSimpleClientset(&tc.target)
 			k, _ := kubernetes.NewFakeKubernetes(client)
 
 			d := newPodDisruptorForTesting(controller, k.PodHelper(tc.selector.Namespace), tc.selector)
@@ -336,7 +336,7 @@ func Test_PodGrpcPFaultInjection(t *testing.T) {
 	testCases := []struct {
 		title       string
 		selector    PodSelector
-		target      *corev1.Pod
+		target      corev1.Pod
 		fault       GrpcFault
 		opts        GrpcDisruptionOptions
 		duration    time.Duration
@@ -476,11 +476,11 @@ func Test_PodGrpcPFaultInjection(t *testing.T) {
 
 			controller := &fakeAgentController{
 				namespace: tc.selector.Namespace,
-				targets:   []corev1.Pod{*tc.target},
+				targets:   []corev1.Pod{tc.target},
 				executor:  executor,
 			}
 
-			client := fake.NewSimpleClientset(tc.target)
+			client := fake.NewSimpleClientset(&tc.target)
 			k, _ := kubernetes.NewFakeKubernetes(client)
 
 			d := newPodDisruptorForTesting(controller, k.PodHelper(tc.selector.Namespace), tc.selector)

--- a/pkg/disruptors/pod_test.go
+++ b/pkg/disruptors/pod_test.go
@@ -239,9 +239,7 @@ func Test_PodHTTPFaultInjection(t *testing.T) {
 			},
 			target: builders.NewPodBuilder("noip").
 				WithNamespace("test-ns").
-				WithLabels(map[string]string{
-					"app": "myapp",
-				}).
+				WithLabel("app", "myapp").
 				WithContainer(
 					*builders.NewContainerBuilder("noip").
 						WithPort("http", 80).
@@ -268,9 +266,7 @@ func Test_PodHTTPFaultInjection(t *testing.T) {
 			},
 			target: builders.NewPodBuilder("hostnet").
 				WithNamespace("test-ns").
-				WithLabels(map[string]string{
-					"app": "myapp",
-				}).
+				WithLabel("app", "myapp").
 				WithHostNetwork(true).
 				WithIP("192.0.2.6").
 				WithContainer(

--- a/pkg/disruptors/pod_test.go
+++ b/pkg/disruptors/pod_test.go
@@ -57,7 +57,11 @@ func (f *fakeAgentController) Visit(_ context.Context, visitor func(corev1.Pod) 
 	return nil
 }
 
-func newPodDisruptorForTesting(controller AgentController, podHelper helpers.PodHelper, podSelector PodSelector) PodDisruptor {
+func newPodDisruptorForTesting(
+	controller AgentController,
+	podHelper helpers.PodHelper,
+	podSelector PodSelector,
+) PodDisruptor {
 	return &podDisruptor{
 		controller: controller,
 		podFilter: helpers.PodFilter{
@@ -131,6 +135,7 @@ func Test_PodHTTPFaultInjection(t *testing.T) {
 			target: buildPodWithPort("my-app-pod", "http", 80),
 			// TODO: Make expectedCmd better represent the actual result ([]string), as it currently looks like we
 			// are asserting a broken behavior (e.g. lack of quotes in -b) which is not the case.
+			//nolint:lll
 			expectedCmds: []string{"xk6-disruptor-agent http -d 60s -t 80 -r 0.1 -e 500 -b {\"error\": 500} --upstream-host 192.0.2.6"},
 			expectError:  false,
 			cmdError:     nil,

--- a/pkg/disruptors/service_test.go
+++ b/pkg/disruptors/service_test.go
@@ -23,9 +23,9 @@ func Test_NewServiceDisruptor(t *testing.T) {
 		title       string
 		name        string
 		namespace   string
-		service     *corev1.Service
-		pods        []*corev1.Pod
-		endpoints   []*corev1.Endpoints
+		service     corev1.Service
+		pods        []corev1.Pod
+		endpoints   []corev1.Endpoints
 		options     ServiceDisruptorOptions
 		expectError bool
 	}{
@@ -38,14 +38,14 @@ func Test_NewServiceDisruptor(t *testing.T) {
 				WithSelectorLabel("app", "test").
 				WithPort("http", 80, intstr.FromInt(80)).
 				Build(),
-			pods: []*corev1.Pod{
+			pods: []corev1.Pod{
 				builders.NewPodBuilder("pod-1").
 					WithNamespace("test-ns").
 					WithLabel("app", "test").
 					WithIP("192.0.2.6").
 					Build(),
 			},
-			endpoints: []*corev1.Endpoints{
+			endpoints: []corev1.Endpoints{
 				builders.NewEndPointsBuilder("test-svc").
 					WithNamespace("test-ns").
 					WithSubset("http", 80, []string{"pod-1"}).
@@ -65,8 +65,8 @@ func Test_NewServiceDisruptor(t *testing.T) {
 				WithSelectorLabel("app", "test").
 				WithPort("http", 80, intstr.FromInt(80)).
 				Build(),
-			pods:        []*corev1.Pod{},
-			endpoints:   []*corev1.Endpoints{},
+			pods:        []corev1.Pod{},
+			endpoints:   []corev1.Endpoints{},
 			options:     ServiceDisruptorOptions{},
 			expectError: false,
 		},
@@ -79,8 +79,8 @@ func Test_NewServiceDisruptor(t *testing.T) {
 				WithSelectorLabel("app", "test").
 				WithPort("http", 80, intstr.FromInt(80)).
 				Build(),
-			pods:        []*corev1.Pod{},
-			endpoints:   []*corev1.Endpoints{},
+			pods:        []corev1.Pod{},
+			endpoints:   []corev1.Endpoints{},
 			options:     ServiceDisruptorOptions{},
 			expectError: true,
 		},
@@ -93,8 +93,8 @@ func Test_NewServiceDisruptor(t *testing.T) {
 				WithSelectorLabel("app", "test").
 				WithPort("http", 80, intstr.FromInt(80)).
 				Build(),
-			pods:        []*corev1.Pod{},
-			endpoints:   []*corev1.Endpoints{},
+			pods:        []corev1.Pod{},
+			endpoints:   []corev1.Endpoints{},
 			options:     ServiceDisruptorOptions{},
 			expectError: true,
 		},
@@ -107,12 +107,12 @@ func Test_NewServiceDisruptor(t *testing.T) {
 			t.Parallel()
 
 			objs := []kruntime.Object{}
-			objs = append(objs, tc.service)
-			for _, p := range tc.pods {
-				objs = append(objs, p)
+			objs = append(objs, &tc.service)
+			for p := range tc.pods {
+				objs = append(objs, &tc.pods[p])
 			}
-			for _, e := range tc.endpoints {
-				objs = append(objs, e)
+			for e := range tc.endpoints {
+				objs = append(objs, &tc.endpoints[e])
 			}
 
 			client := fake.NewSimpleClientset(objs...)

--- a/pkg/disruptors/service_test.go
+++ b/pkg/disruptors/service_test.go
@@ -35,16 +35,8 @@ func Test_NewServiceDisruptor(t *testing.T) {
 			namespace: "test-ns",
 			service: builders.NewServiceBuilder("test-svc").
 				WithNamespace("test-ns").
-				WithSelector(map[string]string{
-					"app": "test",
-				}).
-				WithPorts([]corev1.ServicePort{
-					{
-						Name:       "http",
-						Port:       80,
-						TargetPort: intstr.FromInt(80),
-					},
-				}).
+				WithSelectorLabel("app", "test").
+				WithPort("http", 80, intstr.FromInt(80)).
 				Build(),
 			pods: []*corev1.Pod{
 				builders.NewPodBuilder("pod-1").
@@ -56,14 +48,7 @@ func Test_NewServiceDisruptor(t *testing.T) {
 			endpoints: []*corev1.Endpoints{
 				builders.NewEndPointsBuilder("test-svc").
 					WithNamespace("test-ns").
-					WithSubset(
-						[]corev1.EndpointPort{
-							{
-								Name: "http",
-								Port: 80,
-							},
-						},
-						[]string{"pod-1"}).
+					WithSubset("http", 80, []string{"pod-1"}).
 					Build(),
 			},
 			options: ServiceDisruptorOptions{
@@ -77,16 +62,8 @@ func Test_NewServiceDisruptor(t *testing.T) {
 			namespace: "test-ns",
 			service: builders.NewServiceBuilder("test-svc").
 				WithNamespace("test-ns").
-				WithSelector(map[string]string{
-					"app": "test",
-				}).
-				WithPorts([]corev1.ServicePort{
-					{
-						Name:       "http",
-						Port:       80,
-						TargetPort: intstr.FromInt(80),
-					},
-				}).
+				WithSelectorLabel("app", "test").
+				WithPort("http", 80, intstr.FromInt(80)).
 				Build(),
 			pods:        []*corev1.Pod{},
 			endpoints:   []*corev1.Endpoints{},
@@ -99,16 +76,8 @@ func Test_NewServiceDisruptor(t *testing.T) {
 			namespace: "test-ns",
 			service: builders.NewServiceBuilder("other-svc").
 				WithNamespace("test-ns").
-				WithSelector(map[string]string{
-					"app": "test",
-				}).
-				WithPorts([]corev1.ServicePort{
-					{
-						Name:       "http",
-						Port:       80,
-						TargetPort: intstr.FromInt(80),
-					},
-				}).
+				WithSelectorLabel("app", "test").
+				WithPort("http", 80, intstr.FromInt(80)).
 				Build(),
 			pods:        []*corev1.Pod{},
 			endpoints:   []*corev1.Endpoints{},
@@ -121,16 +90,8 @@ func Test_NewServiceDisruptor(t *testing.T) {
 			namespace: "test-ns",
 			service: builders.NewServiceBuilder("test-svc").
 				WithNamespace("test-ns").
-				WithSelector(map[string]string{
-					"app": "test",
-				}).
-				WithPorts([]corev1.ServicePort{
-					{
-						Name:       "http",
-						Port:       80,
-						TargetPort: intstr.FromInt(80),
-					},
-				}).
+				WithSelectorLabel("app", "test").
+				WithPort("http", 80, intstr.FromInt(80)).
 				Build(),
 			pods:        []*corev1.Pod{},
 			endpoints:   []*corev1.Endpoints{},

--- a/pkg/disruptors/service_test.go
+++ b/pkg/disruptors/service_test.go
@@ -49,9 +49,7 @@ func Test_NewServiceDisruptor(t *testing.T) {
 			pods: []*corev1.Pod{
 				builders.NewPodBuilder("pod-1").
 					WithNamespace("test-ns").
-					WithLabels(map[string]string{
-						"app": "test",
-					}).
+					WithLabel("app", "test").
 					WithIP("192.0.2.6").
 					Build(),
 			},

--- a/pkg/disruptors/service_test.go
+++ b/pkg/disruptors/service_test.go
@@ -25,7 +25,6 @@ func Test_NewServiceDisruptor(t *testing.T) {
 		namespace   string
 		service     corev1.Service
 		pods        []corev1.Pod
-		endpoints   []corev1.Endpoints
 		options     ServiceDisruptorOptions
 		expectError bool
 	}{
@@ -45,29 +44,9 @@ func Test_NewServiceDisruptor(t *testing.T) {
 					WithIP("192.0.2.6").
 					Build(),
 			},
-			endpoints: []corev1.Endpoints{
-				builders.NewEndPointsBuilder("test-svc").
-					WithNamespace("test-ns").
-					WithSubset("http", 80, []string{"pod-1"}).
-					Build(),
-			},
 			options: ServiceDisruptorOptions{
 				InjectTimeout: -1,
 			},
-			expectError: false,
-		},
-		{
-			title:     "no endpoints",
-			name:      "test-svc",
-			namespace: "test-ns",
-			service: builders.NewServiceBuilder("test-svc").
-				WithNamespace("test-ns").
-				WithSelectorLabel("app", "test").
-				WithPort("http", 80, intstr.FromInt(80)).
-				Build(),
-			pods:        []corev1.Pod{},
-			endpoints:   []corev1.Endpoints{},
-			options:     ServiceDisruptorOptions{},
 			expectError: false,
 		},
 		{
@@ -80,7 +59,6 @@ func Test_NewServiceDisruptor(t *testing.T) {
 				WithPort("http", 80, intstr.FromInt(80)).
 				Build(),
 			pods:        []corev1.Pod{},
-			endpoints:   []corev1.Endpoints{},
 			options:     ServiceDisruptorOptions{},
 			expectError: true,
 		},
@@ -94,7 +72,6 @@ func Test_NewServiceDisruptor(t *testing.T) {
 				WithPort("http", 80, intstr.FromInt(80)).
 				Build(),
 			pods:        []corev1.Pod{},
-			endpoints:   []corev1.Endpoints{},
 			options:     ServiceDisruptorOptions{},
 			expectError: true,
 		},
@@ -110,9 +87,6 @@ func Test_NewServiceDisruptor(t *testing.T) {
 			objs = append(objs, &tc.service)
 			for p := range tc.pods {
 				objs = append(objs, &tc.pods[p])
-			}
-			for e := range tc.endpoints {
-				objs = append(objs, &tc.endpoints[e])
 			}
 
 			client := fake.NewSimpleClientset(objs...)

--- a/pkg/iptables/iptables_test.go
+++ b/pkg/iptables/iptables_test.go
@@ -87,6 +87,7 @@ func Test_Commands(t *testing.T) {
 				"iptables -D INPUT -p tcp --dport 8080 -j REJECT --reject-with tcp-reset",
 				"iptables -A OUTPUT -t nat -s 127.0.0.0/8 -d 127.0.0.1/32 -p tcp --dport 80 -j REDIRECT --to-port 8080",
 				"iptables -A PREROUTING -t nat ! -i lo -p tcp --dport 80 -j REDIRECT --to-port 8080",
+				//nolint:lll
 				"iptables -A INPUT -i lo -s 127.0.0.0/8 -d 127.0.0.1/32 -p tcp --dport 80 -m state --state ESTABLISHED -j REJECT --reject-with tcp-reset",
 				"iptables -A INPUT ! -i lo -p tcp --dport 80 -m state --state ESTABLISHED -j REJECT --reject-with tcp-reset",
 			},
@@ -106,6 +107,7 @@ func Test_Commands(t *testing.T) {
 			expectedCmds: []string{
 				"iptables -D OUTPUT -t nat -s 127.0.0.0/8 -d 127.0.0.1/32 -p tcp --dport 80 -j REDIRECT --to-port 8080",
 				"iptables -D PREROUTING -t nat ! -i lo -p tcp --dport 80 -j REDIRECT --to-port 8080",
+				//nolint:lll
 				"iptables -D INPUT -i lo -s 127.0.0.0/8 -d 127.0.0.1/32 -p tcp --dport 80 -m state --state ESTABLISHED -j REJECT --reject-with tcp-reset",
 				"iptables -D INPUT ! -i lo -p tcp --dport 80 -m state --state ESTABLISHED -j REJECT --reject-with tcp-reset",
 				"iptables -A INPUT -p tcp --dport 8080 -j REJECT --reject-with tcp-reset",

--- a/pkg/kubernetes/helpers/pods_test.go
+++ b/pkg/kubernetes/helpers/pods_test.go
@@ -87,7 +87,7 @@ func TestPods_Wait(t *testing.T) {
 			}
 
 			pod := builders.NewPodBuilder(tc.name).WithNamespace(testNamespace).Build()
-			_, err = client.CoreV1().Pods(testNamespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+			_, err = client.CoreV1().Pods(testNamespace).Create(context.TODO(), &pod, metav1.CreateOptions{})
 			if !tc.expectError && err != nil {
 				t.Errorf("unexpected error: %v", err)
 				return
@@ -233,7 +233,7 @@ func Test_ListPods(t *testing.T) {
 
 	testCases := []struct {
 		title        string
-		pods         []*corev1.Pod
+		pods         []corev1.Pod
 		namespace    string
 		filter       PodFilter
 		expectError  bool
@@ -241,7 +241,7 @@ func Test_ListPods(t *testing.T) {
 	}{
 		{
 			title: "No matching pod",
-			pods: []*corev1.Pod{
+			pods: []corev1.Pod{
 				builders.NewPodBuilder("pod-without-labels").
 					WithNamespace("test-ns").
 					Build(),
@@ -258,7 +258,7 @@ func Test_ListPods(t *testing.T) {
 		{
 			title:     "No matching namespace",
 			namespace: "test-ns",
-			pods: []*corev1.Pod{
+			pods: []corev1.Pod{
 				builders.NewPodBuilder("pod-with-app-label-in-another-ns").
 					WithNamespace("anotherNamespace").
 					WithLabel("app", "test").
@@ -275,7 +275,7 @@ func Test_ListPods(t *testing.T) {
 		{
 			title:     "one matching pod",
 			namespace: "test-ns",
-			pods: []*corev1.Pod{
+			pods: []corev1.Pod{
 				builders.NewPodBuilder("pod-with-app-label").
 					WithNamespace("test-ns").
 					WithLabel("app", "test").
@@ -294,7 +294,7 @@ func Test_ListPods(t *testing.T) {
 		{
 			title:     "multiple matching pods",
 			namespace: "test-ns",
-			pods: []*corev1.Pod{
+			pods: []corev1.Pod{
 				builders.NewPodBuilder("pod-with-app-label").
 					WithNamespace("test-ns").
 					WithLabel("app", "test").
@@ -318,7 +318,7 @@ func Test_ListPods(t *testing.T) {
 		{
 			title:     "multiple selector labels",
 			namespace: "test-ns",
-			pods: []*corev1.Pod{
+			pods: []corev1.Pod{
 				builders.NewPodBuilder("pod-with-app-label").
 					WithNamespace("test-ns").
 					WithLabel("app", "test").
@@ -348,7 +348,7 @@ func Test_ListPods(t *testing.T) {
 		{
 			title:     "exclude labels",
 			namespace: "test-ns",
-			pods: []*corev1.Pod{
+			pods: []corev1.Pod{
 				builders.NewPodBuilder("pod-with-dev-label").
 					WithNamespace("test-ns").
 					WithLabel("app", "test").
@@ -376,7 +376,7 @@ func Test_ListPods(t *testing.T) {
 		{
 			title:     "Namespace selector",
 			namespace: "test-ns",
-			pods: []*corev1.Pod{
+			pods: []corev1.Pod{
 				builders.NewPodBuilder("pod-in-test-ns").
 					WithNamespace("test-ns").
 					Build(),
@@ -403,8 +403,8 @@ func Test_ListPods(t *testing.T) {
 			t.Parallel()
 
 			pods := []runtime.Object{}
-			for _, p := range tc.pods {
-				pods = append(pods, p)
+			for p := range tc.pods {
+				pods = append(pods, &tc.pods[p])
 			}
 			client := fake.NewSimpleClientset(pods...)
 

--- a/pkg/kubernetes/helpers/pods_test.go
+++ b/pkg/kubernetes/helpers/pods_test.go
@@ -261,11 +261,7 @@ func Test_ListPods(t *testing.T) {
 			pods: []*corev1.Pod{
 				builders.NewPodBuilder("pod-with-app-label-in-another-ns").
 					WithNamespace("anotherNamespace").
-					WithLabels(
-						map[string]string{
-							"app": "test",
-						},
-					).
+					WithLabel("app", "test").
 					Build(),
 			},
 			filter: PodFilter{
@@ -282,11 +278,7 @@ func Test_ListPods(t *testing.T) {
 			pods: []*corev1.Pod{
 				builders.NewPodBuilder("pod-with-app-label").
 					WithNamespace("test-ns").
-					WithLabels(
-						map[string]string{
-							"app": "test",
-						},
-					).
+					WithLabel("app", "test").
 					Build(),
 			},
 			filter: PodFilter{
@@ -305,19 +297,11 @@ func Test_ListPods(t *testing.T) {
 			pods: []*corev1.Pod{
 				builders.NewPodBuilder("pod-with-app-label").
 					WithNamespace("test-ns").
-					WithLabels(
-						map[string]string{
-							"app": "test",
-						},
-					).
+					WithLabel("app", "test").
 					Build(),
 				builders.NewPodBuilder("another-pod-with-app-label").
 					WithNamespace("test-ns").
-					WithLabels(
-						map[string]string{
-							"app": "test",
-						},
-					).
+					WithLabel("app", "test").
 					Build(),
 			},
 			filter: PodFilter{
@@ -337,29 +321,17 @@ func Test_ListPods(t *testing.T) {
 			pods: []*corev1.Pod{
 				builders.NewPodBuilder("pod-with-app-label").
 					WithNamespace("test-ns").
-					WithLabels(
-						map[string]string{
-							"app": "test",
-						},
-					).
+					WithLabel("app", "test").
 					Build(),
 				builders.NewPodBuilder("pod-with-dev-label").
 					WithNamespace("test-ns").
-					WithLabels(
-						map[string]string{
-							"app": "test",
-							"env": "dev",
-						},
-					).
+					WithLabel("app", "test").
+					WithLabel("env", "dev").
 					Build(),
 				builders.NewPodBuilder("pod-with-prod-label").
 					WithNamespace("test-ns").
-					WithLabels(
-						map[string]string{
-							"app": "test",
-							"env": "prod",
-						},
-					).
+					WithLabel("app", "test").
+					WithLabel("env", "prod").
 					Build(),
 			},
 			filter: PodFilter{
@@ -379,21 +351,13 @@ func Test_ListPods(t *testing.T) {
 			pods: []*corev1.Pod{
 				builders.NewPodBuilder("pod-with-dev-label").
 					WithNamespace("test-ns").
-					WithLabels(
-						map[string]string{
-							"app": "test",
-							"env": "dev",
-						},
-					).
+					WithLabel("app", "test").
+					WithLabel("env", "dev").
 					Build(),
 				builders.NewPodBuilder("pod-with-prod-label").
 					WithNamespace("test-ns").
-					WithLabels(
-						map[string]string{
-							"app": "test",
-							"env": "prod",
-						},
-					).
+					WithLabel("app", "test").
+					WithLabel("env", "prod").
 					Build(),
 			},
 			filter: PodFilter{

--- a/pkg/kubernetes/helpers/services_test.go
+++ b/pkg/kubernetes/helpers/services_test.go
@@ -103,7 +103,13 @@ func Test_WaitServiceReady(t *testing.T) {
 
 			client := fake.NewSimpleClientset()
 			if tc.endpoints != nil {
-				_, err := client.CoreV1().Endpoints("default").Create(context.TODO(), tc.endpoints, metav1.CreateOptions{})
+				_, err := client.CoreV1().
+					Endpoints("default").
+					Create(
+						context.TODO(),
+						tc.endpoints,
+						metav1.CreateOptions{},
+					)
 				if err != nil {
 					t.Errorf("error updating endpoint: %v", err)
 				}
@@ -114,7 +120,13 @@ func Test_WaitServiceReady(t *testing.T) {
 					return
 				}
 				time.Sleep(tc.delay)
-				_, err := client.CoreV1().Endpoints("default").Update(context.TODO(), tc.updated, metav1.UpdateOptions{})
+				_, err := client.CoreV1().
+					Endpoints("default").
+					Update(
+						context.TODO(),
+						tc.updated,
+						metav1.UpdateOptions{},
+					)
 				if err != nil {
 					t.Errorf("error updating endpoint: %v", err)
 				}
@@ -289,13 +301,25 @@ func Test_Targets(t *testing.T) {
 			t.Parallel()
 
 			client := fake.NewSimpleClientset()
-			_, err := client.CoreV1().Services(tc.service.Namespace).Create(context.TODO(), &tc.service, metav1.CreateOptions{})
+			_, err := client.CoreV1().
+				Services(tc.service.Namespace).
+				Create(
+					context.TODO(),
+					&tc.service,
+					metav1.CreateOptions{},
+				)
 			if err != nil {
 				t.Errorf("error creating service: %v", err)
 			}
 
 			for p := range tc.pods {
-				_, err = client.CoreV1().Pods(tc.namespace).Create(context.TODO(), &tc.pods[p], metav1.CreateOptions{})
+				_, err = client.CoreV1().
+					Pods(tc.namespace).
+					Create(
+						context.TODO(),
+						&tc.pods[p],
+						metav1.CreateOptions{},
+					)
 				if err != nil {
 					t.Errorf("error creating endpoint: %v", err)
 				}

--- a/pkg/kubernetes/helpers/services_test.go
+++ b/pkg/kubernetes/helpers/services_test.go
@@ -293,11 +293,8 @@ func Test_Targets(t *testing.T) {
 			pods: []*corev1.Pod{
 				builders.NewPodBuilder("pod-1").
 					WithNamespace("test-ns").
-					WithLabels(
-						map[string]string{
-							"app": "test",
-						},
-					).Build(),
+					WithLabel("app", "test").
+					Build(),
 			},
 			expectError:  false,
 			expectedPods: []string{"pod-1"},

--- a/pkg/testutils/e2e/deploy/deploy.go
+++ b/pkg/testutils/e2e/deploy/deploy.go
@@ -15,10 +15,10 @@ import (
 )
 
 // RunPod creates a pod and waits it for be running
-func RunPod(k8s kubernetes.Kubernetes, ns string, pod *corev1.Pod, timeout time.Duration) error {
+func RunPod(k8s kubernetes.Kubernetes, ns string, pod corev1.Pod, timeout time.Duration) error {
 	_, err := k8s.Client().CoreV1().Pods(ns).Create(
 		context.TODO(),
-		pod,
+		&pod,
 		metav1.CreateOptions{},
 	)
 	if err != nil {
@@ -45,8 +45,8 @@ func RunPod(k8s kubernetes.Kubernetes, ns string, pod *corev1.Pod, timeout time.
 func ExposeApp(
 	k8s kubernetes.Kubernetes,
 	namespace string,
-	pod *corev1.Pod,
-	svc *corev1.Service,
+	pod corev1.Pod,
+	svc corev1.Service,
 	port intstr.IntOrString,
 	timeout time.Duration,
 ) error {
@@ -60,7 +60,7 @@ func ExposeApp(
 	timeLeft := timeout - time.Since(start)
 	_, err = k8s.Client().CoreV1().Services(namespace).Create(
 		context.TODO(),
-		svc,
+		&svc,
 		metav1.CreateOptions{},
 	)
 	if err != nil {
@@ -80,7 +80,7 @@ func ExposeApp(
 
 	_, err = k8s.Client().NetworkingV1().Ingresses(namespace).Create(
 		context.TODO(),
-		ingress,
+		&ingress,
 		metav1.CreateOptions{},
 	)
 	if err != nil {

--- a/pkg/testutils/e2e/fixtures/fixtures.go
+++ b/pkg/testutils/e2e/fixtures/fixtures.go
@@ -9,7 +9,7 @@ import (
 )
 
 // BuildHttpbinPod returns the definition for deploying Httpbin as a Pod
-func BuildHttpbinPod() *corev1.Pod {
+func BuildHttpbinPod() corev1.Pod {
 	c := builders.NewContainerBuilder("httpbin").
 		WithImage("kennethreitz/httpbin").
 		WithPullPolicy(corev1.PullIfNotPresent).
@@ -23,7 +23,7 @@ func BuildHttpbinPod() *corev1.Pod {
 }
 
 // BuildGrpcpbinPod returns the definition for deploying grpcbin as a Pod
-func BuildGrpcpbinPod() *corev1.Pod {
+func BuildGrpcpbinPod() corev1.Pod {
 	c := builders.NewContainerBuilder("grpcbin").
 		WithImage("moul/grpcbin").
 		WithPullPolicy(corev1.PullIfNotPresent).
@@ -37,7 +37,7 @@ func BuildGrpcpbinPod() *corev1.Pod {
 }
 
 // BuildHttpbinService returns a Service definition that exposes httpbin pods
-func BuildHttpbinService() *corev1.Service {
+func BuildHttpbinService() corev1.Service {
 	return builders.NewServiceBuilder("httpbin").
 		WithSelectorLabel("app", "httpbin").
 		WithPort("http", 80, intstr.FromString("http")).
@@ -45,7 +45,7 @@ func BuildHttpbinService() *corev1.Service {
 }
 
 // BuildGrpcbinService returns a Service definition that exposes grpcbin pods at the node port 30000
-func BuildGrpcbinService() *corev1.Service {
+func BuildGrpcbinService() corev1.Service {
 	return builders.NewServiceBuilder("grpcbin").
 		WithSelectorLabel("app", "grpcbin").
 		WithServiceType(corev1.ServiceTypeClusterIP).
@@ -55,7 +55,7 @@ func BuildGrpcbinService() *corev1.Service {
 }
 
 // BuildBusyBoxPod returns the definition of a Pod that runs busybox and waits 5min before completing
-func BuildBusyBoxPod() *corev1.Pod {
+func BuildBusyBoxPod() corev1.Pod {
 	c := builders.NewContainerBuilder("busybox").
 		WithImage("busybox").
 		WithPullPolicy(corev1.PullIfNotPresent).
@@ -70,7 +70,7 @@ func BuildBusyBoxPod() *corev1.Pod {
 
 // BuildPausedPod returns the definition of a Pod that runs the paused image in a container
 // creating a "no-op" dummy Pod.
-func BuildPausedPod() *corev1.Pod {
+func BuildPausedPod() corev1.Pod {
 	c := builders.NewContainerBuilder("paused").
 		WithImage("k8s.gcr.io/pause").
 		WithPullPolicy(corev1.PullIfNotPresent).
@@ -82,7 +82,7 @@ func BuildPausedPod() *corev1.Pod {
 }
 
 // BuildNginxPod returns the definition of a Pod that runs Nginx
-func BuildNginxPod() *corev1.Pod {
+func BuildNginxPod() corev1.Pod {
 	c := builders.NewContainerBuilder("busybox").
 		WithImage("nginx").
 		WithPullPolicy(corev1.PullIfNotPresent).
@@ -96,7 +96,7 @@ func BuildNginxPod() *corev1.Pod {
 }
 
 // BuildNginxService returns the definition of a Service that exposes the nginx pod(s)
-func BuildNginxService() *corev1.Service {
+func BuildNginxService() corev1.Service {
 	return builders.NewServiceBuilder("nginx").
 		WithSelectorLabel("app", "nginx").
 		WithPort("http", 80, intstr.FromInt(80)).

--- a/pkg/testutils/e2e/fixtures/fixtures.go
+++ b/pkg/testutils/e2e/fixtures/fixtures.go
@@ -39,41 +39,18 @@ func BuildGrpcpbinPod() *corev1.Pod {
 // BuildHttpbinService returns a Service definition that exposes httpbin pods
 func BuildHttpbinService() *corev1.Service {
 	return builders.NewServiceBuilder("httpbin").
-		WithSelector(
-			map[string]string{
-				"app": "httpbin",
-			},
-		).
-		WithPorts(
-			[]corev1.ServicePort{
-				{
-					Name:       "http",
-					Port:       80,
-					TargetPort: intstr.FromString("http"),
-				},
-			},
-		).
+		WithSelectorLabel("app", "httpbin").
+		WithPort("http", 80, intstr.FromString("http")).
 		Build()
 }
 
 // BuildGrpcbinService returns a Service definition that exposes grpcbin pods at the node port 30000
 func BuildGrpcbinService() *corev1.Service {
 	return builders.NewServiceBuilder("grpcbin").
-		WithSelector(
-			map[string]string{
-				"app": "grpcbin",
-			},
-		).
+		WithSelectorLabel("app", "grpcbin").
 		WithServiceType(corev1.ServiceTypeClusterIP).
 		WithAnnotation("projectcontour.io/upstream-protocol.h2c", "9000").
-		WithPorts(
-			[]corev1.ServicePort{
-				{
-					Name: "grpc",
-					Port: 9000,
-				},
-			},
-		).
+		WithPort("grpc", 9000, intstr.FromInt(9000)).
 		Build()
 }
 
@@ -121,18 +98,7 @@ func BuildNginxPod() *corev1.Pod {
 // BuildNginxService returns the definition of a Service that exposes the nginx pod(s)
 func BuildNginxService() *corev1.Service {
 	return builders.NewServiceBuilder("nginx").
-		WithSelector(
-			map[string]string{
-				"app": "nginx",
-			},
-		).
-		WithPorts(
-			[]corev1.ServicePort{
-				{
-					Name: "http",
-					Port: 80,
-				},
-			},
-		).
+		WithSelectorLabel("app", "nginx").
+		WithPort("http", 80, intstr.FromInt(80)).
 		Build()
 }

--- a/pkg/testutils/e2e/fixtures/fixtures.go
+++ b/pkg/testutils/e2e/fixtures/fixtures.go
@@ -17,11 +17,7 @@ func BuildHttpbinPod() *corev1.Pod {
 		Build()
 
 	return builders.NewPodBuilder("httpbin").
-		WithLabels(
-			map[string]string{
-				"app": "httpbin",
-			},
-		).
+		WithLabel("app", "httpbin").
 		WithContainer(c).
 		Build()
 }
@@ -35,11 +31,7 @@ func BuildGrpcpbinPod() *corev1.Pod {
 		Build()
 
 	return builders.NewPodBuilder("grpcbin").
-		WithLabels(
-			map[string]string{
-				"app": "grpcbin",
-			},
-		).
+		WithLabel("app", "grpcbin").
 		WithContainer(c).
 		Build()
 }
@@ -94,11 +86,7 @@ func BuildBusyBoxPod() *corev1.Pod {
 		Build()
 
 	return builders.NewPodBuilder("busybox").
-		WithLabels(
-			map[string]string{
-				"app": "busybox",
-			},
-		).
+		WithLabel("app", "busybox").
 		WithContainer(c).
 		Build()
 }
@@ -125,11 +113,7 @@ func BuildNginxPod() *corev1.Pod {
 		Build()
 
 	return builders.NewPodBuilder("nginx").
-		WithLabels(
-			map[string]string{
-				"app": "nginx",
-			},
-		).
+		WithLabel("app", "nginx").
 		WithContainer(c).
 		Build()
 }

--- a/pkg/testutils/e2e/fixtures/fixtures.go
+++ b/pkg/testutils/e2e/fixtures/fixtures.go
@@ -10,7 +10,7 @@ import (
 
 // BuildHttpbinPod returns the definition for deploying Httpbin as a Pod
 func BuildHttpbinPod() *corev1.Pod {
-	c := *builders.NewContainerBuilder("httpbin").
+	c := builders.NewContainerBuilder("httpbin").
 		WithImage("kennethreitz/httpbin").
 		WithPullPolicy(corev1.PullIfNotPresent).
 		WithPort("http", 80).
@@ -24,7 +24,7 @@ func BuildHttpbinPod() *corev1.Pod {
 
 // BuildGrpcpbinPod returns the definition for deploying grpcbin as a Pod
 func BuildGrpcpbinPod() *corev1.Pod {
-	c := *builders.NewContainerBuilder("grpcbin").
+	c := builders.NewContainerBuilder("grpcbin").
 		WithImage("moul/grpcbin").
 		WithPullPolicy(corev1.PullIfNotPresent).
 		WithPort("grpc", 9000).
@@ -56,7 +56,7 @@ func BuildGrpcbinService() *corev1.Service {
 
 // BuildBusyBoxPod returns the definition of a Pod that runs busybox and waits 5min before completing
 func BuildBusyBoxPod() *corev1.Pod {
-	c := *builders.NewContainerBuilder("busybox").
+	c := builders.NewContainerBuilder("busybox").
 		WithImage("busybox").
 		WithPullPolicy(corev1.PullIfNotPresent).
 		WithCommand("sleep", "300").
@@ -71,7 +71,7 @@ func BuildBusyBoxPod() *corev1.Pod {
 // BuildPausedPod returns the definition of a Pod that runs the paused image in a container
 // creating a "no-op" dummy Pod.
 func BuildPausedPod() *corev1.Pod {
-	c := *builders.NewContainerBuilder("paused").
+	c := builders.NewContainerBuilder("paused").
 		WithImage("k8s.gcr.io/pause").
 		WithPullPolicy(corev1.PullIfNotPresent).
 		Build()
@@ -83,7 +83,7 @@ func BuildPausedPod() *corev1.Pod {
 
 // BuildNginxPod returns the definition of a Pod that runs Nginx
 func BuildNginxPod() *corev1.Pod {
-	c := *builders.NewContainerBuilder("busybox").
+	c := builders.NewContainerBuilder("busybox").
 		WithImage("nginx").
 		WithPullPolicy(corev1.PullIfNotPresent).
 		WithPort("http", 80).

--- a/pkg/testutils/kubernetes/builders/client.go
+++ b/pkg/testutils/kubernetes/builders/client.go
@@ -44,9 +44,9 @@ type ClientBuilder interface {
 	// WithNamespace initializes the client with the given namespace
 	WithNamespace(namespace string) ClientBuilder
 	// WithPods initializes the client with the given Pods
-	WithPods(pods ...*corev1.Pod) ClientBuilder
+	WithPods(pods ...corev1.Pod) ClientBuilder
 	// WithServices initializes the client with the given Services
-	WithServices(pods ...*corev1.Service) ClientBuilder
+	WithServices(pods ...corev1.Service) ClientBuilder
 	// WithPodObserver adds a PodObserver that receives notifications of specific events
 	WithPodObserver(namespace string, event ObjectEvent, observer PodObserver) ClientBuilder
 	// WithContext sets a context allows cancelling object observers
@@ -95,9 +95,15 @@ func (b *clientBuilder) WithObjects(objs ...runtime.Object) ClientBuilder {
 	return b
 }
 
-func (b *clientBuilder) WithPods(pods ...*corev1.Pod) ClientBuilder {
-	for _, p := range pods {
-		_, err := b.client.CoreV1().Pods(p.Namespace).Create(context.TODO(), p, metav1.CreateOptions{})
+func (b *clientBuilder) WithPods(pods ...corev1.Pod) ClientBuilder {
+	for p := range pods {
+		_, err := b.client.CoreV1().
+			Pods(pods[p].Namespace).
+			Create(
+				context.TODO(),
+				&pods[p],
+				metav1.CreateOptions{},
+			)
 		if err != nil {
 			b.errors = append(b.errors, err)
 		}
@@ -117,9 +123,16 @@ func (b *clientBuilder) WithNamespace(namespace string) ClientBuilder {
 	return b
 }
 
-func (b *clientBuilder) WithServices(services ...*corev1.Service) ClientBuilder {
-	for _, s := range services {
-		_, err := b.client.CoreV1().Services(s.Namespace).Create(context.TODO(), s, metav1.CreateOptions{})
+func (b *clientBuilder) WithServices(services ...corev1.Service) ClientBuilder {
+	for s := range services {
+		_, err := b.client.CoreV1().
+			Services(services[s].
+				Namespace).
+			Create(
+				context.TODO(),
+				&services[s],
+				metav1.CreateOptions{},
+			)
 		if err != nil {
 			b.errors = append(b.errors, err)
 		}

--- a/pkg/testutils/kubernetes/builders/client_test.go
+++ b/pkg/testutils/kubernetes/builders/client_test.go
@@ -32,7 +32,7 @@ func Test_WithPodObservers(t *testing.T) {
 			expectTimeout: false,
 			setup: func(client *fake.Clientset) error {
 				pod := NewPodBuilder("pod1").WithNamespace("default").Build()
-				_, err := client.CoreV1().Pods("default").Create(context.TODO(), pod, metav1.CreateOptions{})
+				_, err := client.CoreV1().Pods("default").Create(context.TODO(), &pod, metav1.CreateOptions{})
 				return err
 			},
 		},
@@ -46,15 +46,15 @@ func Test_WithPodObservers(t *testing.T) {
 			setup: func(client *fake.Clientset) error {
 				pod := NewPodBuilder("pod1").WithNamespace("default").WithAnnotation("test.updated", "").Build()
 
-				pod, err := client.CoreV1().Pods("default").Create(context.TODO(), pod, metav1.CreateOptions{})
+				created, err := client.CoreV1().Pods("default").Create(context.TODO(), &pod, metav1.CreateOptions{})
 				if err != nil {
 					return err
 				}
 
 				time.Sleep(time.Second)
 
-				pod.Annotations["test.updated"] = "true"
-				_, err = client.CoreV1().Pods("default").Update(context.TODO(), pod, metav1.UpdateOptions{})
+				created.Annotations["test.updated"] = "true"
+				_, err = client.CoreV1().Pods("default").Update(context.TODO(), created, metav1.UpdateOptions{})
 				return err
 			},
 		},
@@ -67,7 +67,7 @@ func Test_WithPodObservers(t *testing.T) {
 			expectTimeout: true,
 			setup: func(client *fake.Clientset) error {
 				pod := NewPodBuilder("pod1").WithNamespace("default").Build()
-				_, err := client.CoreV1().Pods("default").Create(context.TODO(), pod, metav1.CreateOptions{})
+				_, err := client.CoreV1().Pods("default").Create(context.TODO(), &pod, metav1.CreateOptions{})
 				return err
 			},
 		},

--- a/pkg/testutils/kubernetes/builders/container.go
+++ b/pkg/testutils/kubernetes/builders/container.go
@@ -15,7 +15,7 @@ type ContainerBuilder interface {
 	// WithCapabilites adds capabilities to the container's security context
 	WithCapabilities(capabilities ...corev1.Capability) ContainerBuilder
 	// Build returns a Pod with the attributes defined in the PodBuilder
-	Build() *corev1.Container
+	Build() corev1.Container
 	// WithEnvVarFromField adds an environment variable to the container
 	WithEnvVar(name string, value string) ContainerBuilder
 	// WithEnvVarFromField adds an environment variable to the container referencing a field
@@ -87,8 +87,8 @@ func (b *containerBuilder) WithEnvVarFromField(name string, path string) Contain
 	return b
 }
 
-func (b *containerBuilder) Build() *corev1.Container {
-	return &corev1.Container{
+func (b *containerBuilder) Build() corev1.Container {
+	return corev1.Container{
 		Name:            b.name,
 		Image:           b.image,
 		ImagePullPolicy: b.imagePolicy,

--- a/pkg/testutils/kubernetes/builders/ingress.go
+++ b/pkg/testutils/kubernetes/builders/ingress.go
@@ -23,7 +23,9 @@ type IngressBuilder interface {
 	// WithAddress sets the ingress loadbalancer address
 	WithAddress(addr string) IngressBuilder
 	// Build returns the Ingress
-	Build() *networking.Ingress
+	Build() networking.Ingress
+	// BuildAsPtr returns a reference to the Ingress
+	BuildAsPtr() *networking.Ingress
 }
 
 // ingressBuilder maintains the configuration for building an Ingress
@@ -78,10 +80,10 @@ func (b *ingressBuilder) WithAddress(addr string) IngressBuilder {
 	return b
 }
 
-func (b *ingressBuilder) Build() *networking.Ingress {
+func (b *ingressBuilder) Build() networking.Ingress {
 	pathType := networking.PathType("Prefix")
 
-	return &networking.Ingress{
+	return networking.Ingress{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "networking/v1",
 			Kind:       "Ingress",
@@ -123,4 +125,9 @@ func (b *ingressBuilder) Build() *networking.Ingress {
 			},
 		},
 	}
+}
+
+func (b *ingressBuilder) BuildAsPtr() *networking.Ingress {
+	ingress := b.Build()
+	return &ingress
 }

--- a/pkg/testutils/kubernetes/builders/pod.go
+++ b/pkg/testutils/kubernetes/builders/pod.go
@@ -8,7 +8,7 @@ import (
 // PodBuilder defines the methods for building a Pod
 type PodBuilder interface {
 	// Build returns a Pod with the attributes defined in the PodBuilder
-	Build() *corev1.Pod
+	Build() corev1.Pod
 	// WithNamespace sets namespace for the pod to be built
 	WithNamespace(namespace string) PodBuilder
 	// WithDefaultNamespace sets namespace for the pod as "default"
@@ -97,7 +97,7 @@ func (b *podBuilder) WithContainer(c corev1.Container) PodBuilder {
 	return b
 }
 
-func (b *podBuilder) Build() *corev1.Pod {
+func (b *podBuilder) Build() corev1.Pod {
 	pod := corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -127,5 +127,5 @@ func (b *podBuilder) Build() *corev1.Pod {
 		pod.Status.PodIPs = []corev1.PodIP{{IP: b.ip}}
 	}
 
-	return &pod
+	return pod
 }

--- a/pkg/testutils/kubernetes/builders/pod.go
+++ b/pkg/testutils/kubernetes/builders/pod.go
@@ -11,8 +11,13 @@ type PodBuilder interface {
 	Build() *corev1.Pod
 	// WithNamespace sets namespace for the pod to be built
 	WithNamespace(namespace string) PodBuilder
-	// WithLabels sets the labels for the pod to be built
+	// WithDefaultNamespace sets namespace for the pod as "default"
+	// By default, the Pod has no namespace set to allow overriding it when creating the resource in k8s
+	WithDefaultNamespace() PodBuilder
+	// WithLabels sets the labels to the pod (overrides any previously set labels)
 	WithLabels(labels map[string]string) PodBuilder
+	// WithLabel adds a label to the Pod
+	WithLabel(name string, value string) PodBuilder
 	// WithAnnotation adds an annotation
 	WithAnnotation(name string, value string) PodBuilder
 	// WithPhase sets the PodPhase for the pod to be built
@@ -43,11 +48,17 @@ func NewPodBuilder(name string) PodBuilder {
 	return &podBuilder{
 		name:        name,
 		annotations: map[string]string{},
+		labels:      map[string]string{},
 	}
 }
 
 func (b *podBuilder) WithNamespace(namespace string) PodBuilder {
 	b.namespace = namespace
+	return b
+}
+
+func (b *podBuilder) WithDefaultNamespace() PodBuilder {
+	b.namespace = metav1.NamespaceDefault
 	return b
 }
 
@@ -63,6 +74,11 @@ func (b *podBuilder) WithIP(ip string) PodBuilder {
 
 func (b *podBuilder) WithLabels(labels map[string]string) PodBuilder {
 	b.labels = labels
+	return b
+}
+
+func (b *podBuilder) WithLabel(name string, value string) PodBuilder {
+	b.labels[name] = value
 	return b
 }
 

--- a/pkg/testutils/kubernetes/builders/service.go
+++ b/pkg/testutils/kubernetes/builders/service.go
@@ -12,7 +12,9 @@ import (
 // ServiceBuilder defines the methods for building a service
 type ServiceBuilder interface {
 	// Build returns a Service with the attributes defined in the ServiceBuilder
-	Build() *corev1.Service
+	Build() corev1.Service
+	// BuildAsPtr returns a Service with the attributes defined in the ServiceBuilder as a pointer
+	BuildAsPtr() *corev1.Service
 	// WithNamespace sets namespace for the pod to be built
 	WithNamespace(namespace string) ServiceBuilder
 	// WithPorts sets the ports exposed by the service
@@ -88,8 +90,8 @@ func (s *serviceBuilder) WithAnnotation(key string, value string) ServiceBuilder
 	return s
 }
 
-func (s *serviceBuilder) Build() *corev1.Service {
-	return &corev1.Service{
+func (s *serviceBuilder) Build() corev1.Service {
+	return corev1.Service{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
 			Kind:       "Service",
@@ -107,6 +109,11 @@ func (s *serviceBuilder) Build() *corev1.Service {
 	}
 }
 
+func (s *serviceBuilder) BuildAsPtr() *corev1.Service {
+	svc := s.Build()
+	return &svc
+}
+
 // EndpointsBuilder defines the methods for building a service EndPoints
 type EndpointsBuilder interface {
 	// WithNamespace sets namespace for the pod to be built
@@ -116,7 +123,9 @@ type EndpointsBuilder interface {
 	// WithNotReadyAddresses adds a subset with not ready addresses
 	WithNotReadyAddresses(name string, port int32, pods []string) EndpointsBuilder
 	// Build builds the Endpoints
-	Build() *corev1.Endpoints
+	Build() corev1.Endpoints
+	// BuildAsPtr builds the Endpoints and returns as a pointer
+	BuildAsPtr() *corev1.Endpoints
 }
 
 type endpointsBuilder struct {
@@ -192,8 +201,8 @@ func (b *endpointsBuilder) WithNotReadyAddresses(name string, port int32, pods [
 	return b
 }
 
-func (b *endpointsBuilder) Build() *corev1.Endpoints {
-	return &corev1.Endpoints{
+func (b *endpointsBuilder) Build() corev1.Endpoints {
+	return corev1.Endpoints{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
 			Kind:       "EndPoints",
@@ -204,4 +213,9 @@ func (b *endpointsBuilder) Build() *corev1.Endpoints {
 		},
 		Subsets: b.subsets,
 	}
+}
+
+func (b *endpointsBuilder) BuildAsPtr() *corev1.Endpoints {
+	e := b.Build()
+	return &e
 }

--- a/pkg/testutils/kubernetes/builders/service.go
+++ b/pkg/testutils/kubernetes/builders/service.go
@@ -17,8 +17,12 @@ type ServiceBuilder interface {
 	WithNamespace(namespace string) ServiceBuilder
 	// WithPorts sets the ports exposed by the service
 	WithPorts(ports []corev1.ServicePort) ServiceBuilder
-	// WithSelector sets the service's selector labels
+	// WithPort adds a port to the service
+	WithPort(name string, port int32, target intstr.IntOrString) ServiceBuilder
+	// WithSelector sets the service's selector labels (overrides any previously set label)
 	WithSelector(labels map[string]string) ServiceBuilder
+	// WithSelectorLabel adds a label to the service selector
+	WithSelectorLabel(label string, value string) ServiceBuilder
 	// WithServiceType sets the type of the service (default is NodePort)
 	WithServiceType(t corev1.ServiceType) ServiceBuilder
 	// WithAnnotation adds an annotation to the service
@@ -33,16 +37,7 @@ type serviceBuilder struct {
 	ports       []corev1.ServicePort
 	selector    map[string]string
 	annotations map[string]string
-}
-
-// DefaultServicePorts returns an array of ServicePort with default values
-func DefaultServicePorts() []corev1.ServicePort {
-	return []corev1.ServicePort{
-		{
-			Port:       80,
-			TargetPort: intstr.FromInt(80),
-		},
-	}
+	labels      map[string]string
 }
 
 // NewServiceBuilder creates a new instance of ServiceBuilder with the given pod name
@@ -51,9 +46,10 @@ func NewServiceBuilder(name string) ServiceBuilder {
 	return &serviceBuilder{
 		name:        name,
 		serviceType: corev1.ServiceTypeNodePort,
-		ports:       DefaultServicePorts(),
+		ports:       []corev1.ServicePort{},
 		selector:    map[string]string{},
 		annotations: map[string]string{},
+		labels:      map[string]string{},
 	}
 }
 
@@ -67,6 +63,11 @@ func (s *serviceBuilder) WithPorts(ports []corev1.ServicePort) ServiceBuilder {
 	return s
 }
 
+func (s *serviceBuilder) WithPort(name string, port int32, target intstr.IntOrString) ServiceBuilder {
+	s.ports = append(s.ports, corev1.ServicePort{Name: name, Port: port, TargetPort: target})
+	return s
+}
+
 func (s *serviceBuilder) WithServiceType(serviceType corev1.ServiceType) ServiceBuilder {
 	s.serviceType = serviceType
 	return s
@@ -74,6 +75,11 @@ func (s *serviceBuilder) WithServiceType(serviceType corev1.ServiceType) Service
 
 func (s *serviceBuilder) WithSelector(labels map[string]string) ServiceBuilder {
 	s.selector = labels
+	return s
+}
+
+func (s *serviceBuilder) WithSelectorLabel(label string, value string) ServiceBuilder {
+	s.selector[label] = value
 	return s
 }
 
@@ -106,7 +112,9 @@ type EndpointsBuilder interface {
 	// WithNamespace sets namespace for the pod to be built
 	WithNamespace(namespace string) EndpointsBuilder
 	// WithSubset adds a subset to the Endpoints
-	WithSubset(ports []corev1.EndpointPort, pods []string) EndpointsBuilder
+	WithSubset(name string, port int32, pods []string) EndpointsBuilder
+	// WithNotReadyAddresses adds a subset with not ready addresses
+	WithNotReadyAddresses(name string, port int32, pods []string) EndpointsBuilder
 	// Build builds the Endpoints
 	Build() *corev1.Endpoints
 }
@@ -136,7 +144,7 @@ func randomIP() string {
 	return fmt.Sprintf("%d.%d.%d.%d", b[0], b[1], b[2], b[3])
 }
 
-func (b *endpointsBuilder) WithSubset(ports []corev1.EndpointPort, pods []string) EndpointsBuilder {
+func endpointAddresses(namespace string, pods []string) []corev1.EndpointAddress {
 	addresses := []corev1.EndpointAddress{}
 	for _, p := range pods {
 		addresses = append(
@@ -145,16 +153,39 @@ func (b *endpointsBuilder) WithSubset(ports []corev1.EndpointPort, pods []string
 				IP: randomIP(),
 				TargetRef: &corev1.ObjectReference{
 					Kind:      "Pod",
-					Namespace: b.namespace,
+					Namespace: namespace,
 					Name:      p,
 				},
 			},
 		)
 	}
+	return addresses
+}
 
+func (b *endpointsBuilder) WithSubset(name string, port int32, pods []string) EndpointsBuilder {
 	subset := corev1.EndpointSubset{
-		Ports:     ports,
-		Addresses: addresses,
+		Ports: []corev1.EndpointPort{
+			{
+				Name: name,
+				Port: port,
+			},
+		},
+		Addresses: endpointAddresses(b.namespace, pods),
+	}
+	b.subsets = append(b.subsets, subset)
+
+	return b
+}
+
+func (b *endpointsBuilder) WithNotReadyAddresses(name string, port int32, pods []string) EndpointsBuilder {
+	subset := corev1.EndpointSubset{
+		Ports: []corev1.EndpointPort{
+			{
+				Name: name,
+				Port: port,
+			},
+		},
+		NotReadyAddresses: endpointAddresses(b.namespace, pods),
 	}
 	b.subsets = append(b.subsets, subset)
 

--- a/pkg/utils/kubernetes_test.go
+++ b/pkg/utils/kubernetes_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/xk6-disruptor/pkg/testutils/kubernetes/builders"
 )
 
-func buildPodWithPort(name string, portName string, port int32) *corev1.Pod {
+func buildPodWithPort(name string, portName string, port int32) corev1.Pod {
 	container := builders.NewContainerBuilder(name).
 		WithPort(portName, port).
 		Build()
@@ -22,7 +22,7 @@ func buildPodWithPort(name string, portName string, port int32) *corev1.Pod {
 	return pod
 }
 
-func buildServicWithPort(name string, portName string, port int32, target intstr.IntOrString) *corev1.Service {
+func buildServicWithPort(name string, portName string, port int32, target intstr.IntOrString) corev1.Service {
 	return builders.NewServiceBuilder(name).
 		WithNamespace("test-ns").
 		WithSelectorLabel("app", "test").
@@ -37,8 +37,8 @@ func Test_ServicePortMapping(t *testing.T) {
 		title       string
 		serviceName string
 		namespace   string
-		service     *corev1.Service
-		pod         *corev1.Pod
+		service     corev1.Service
+		pod         corev1.Pod
 		endpoints   *corev1.Endpoints
 		port        uint
 		expectError bool
@@ -102,7 +102,7 @@ func Test_ServicePortMapping(t *testing.T) {
 		t.Run(tc.title, func(t *testing.T) {
 			t.Parallel()
 
-			port, err := MapPort(*tc.service, tc.port, *tc.pod)
+			port, err := MapPort(tc.service, tc.port, tc.pod)
 			if !tc.expectError && err != nil {
 				t.Errorf(" failed: %v", err)
 				return
@@ -131,7 +131,7 @@ func Test_ValidatePort(t *testing.T) {
 	testCases := []struct {
 		title      string
 		namespace  string
-		pod        *corev1.Pod
+		pod        corev1.Pod
 		targetPort uint
 		expect     bool
 	}{
@@ -162,7 +162,7 @@ func Test_ValidatePort(t *testing.T) {
 		t.Run(tc.title, func(t *testing.T) {
 			t.Parallel()
 
-			validation := HasPort(*tc.pod, tc.targetPort)
+			validation := HasPort(tc.pod, tc.targetPort)
 			if validation != tc.expect {
 				t.Errorf("expected %t got %t", tc.expect, validation)
 			}

--- a/pkg/utils/kubernetes_test.go
+++ b/pkg/utils/kubernetes_test.go
@@ -25,18 +25,9 @@ func buildPodWithPort(name string, portName string, port int32) *corev1.Pod {
 func buildServicWithPort(name string, portName string, port int32, target intstr.IntOrString) *corev1.Service {
 	return builders.NewServiceBuilder(name).
 		WithNamespace("test-ns").
-		WithSelector(map[string]string{
-			"app": "test",
-		}).
-		WithPorts(
-			[]corev1.ServicePort{
-				{
-					Name:       portName,
-					Port:       port,
-					TargetPort: target,
-				},
-			},
-		).Build()
+		WithSelectorLabel("app", "test").
+		WithPort(portName, port, target).
+		Build()
 }
 
 func Test_ServicePortMapping(t *testing.T) {

--- a/pkg/utils/kubernetes_test.go
+++ b/pkg/utils/kubernetes_test.go
@@ -16,7 +16,7 @@ func buildPodWithPort(name string, portName string, port int32) *corev1.Pod {
 		Build()
 
 	pod := builders.NewPodBuilder(name).
-		WithContainer(*container).
+		WithContainer(container).
 		Build()
 
 	return pod


### PR DESCRIPTION
# Description
Simplify the construction of test fixtures adding methods to the builders to streamline the most common cases

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [X] I have run linter locally (`make lint`) and all checks pass.
- [X] I have run tests locally (`make test`) and all tests pass.
- [X] I have run relevant e2e test locally (`make e2e-xxx` for `agent`, `disruptors`, `kubernetes` or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
