### PR TITLE
Simplify disruptors

### DIFF
--- a/pkg/disruptors/pod.go
+++ b/pkg/disruptors/pod.go
@@ -34,8 +34,6 @@ type PodDisruptorOptions struct {
 // podDisruptor is an instance of a PodDisruptor initialized with a list of target pods
 type podDisruptor struct {
 	controller AgentController
-	podFilter  helpers.PodFilter
-	podHelper  helpers.PodHelper
 }
 
 // PodSelector defines the criteria for selecting a pod for disruption
@@ -98,8 +96,6 @@ func NewPodDisruptor(
 
 	return &podDisruptor{
 		controller: controller,
-		podFilter:  filter,
-		podHelper:  helper,
 	}, nil
 }
 

--- a/pkg/disruptors/service.go
+++ b/pkg/disruptors/service.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/grafana/xk6-disruptor/pkg/kubernetes"
-	"github.com/grafana/xk6-disruptor/pkg/kubernetes/helpers"
 	"github.com/grafana/xk6-disruptor/pkg/utils"
 
 	corev1 "k8s.io/api/core/v1"
@@ -29,9 +28,6 @@ type ServiceDisruptorOptions struct {
 // serviceDisruptor is an instance of a ServiceDisruptor
 type serviceDisruptor struct {
 	service    corev1.Service
-	namespace  string
-	options    ServiceDisruptorOptions
-	helper     helpers.ServiceHelper
 	controller AgentController
 }
 
@@ -75,9 +71,6 @@ func NewServiceDisruptor(
 
 	return &serviceDisruptor{
 		service:    *svc,
-		namespace:  namespace,
-		options:    options,
-		helper:     sh,
 		controller: controller,
 	}, nil
 }


### PR DESCRIPTION
# Description

Remove unnecessary fields in the implementation of the disruptors to simplify tests 

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make test`) and all tests pass.
- [ ] I have run relevant e2e test locally (`make e2e-xxx` for `agent`, `disruptors`, `kubernetes` or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
