### PR TITLE
agent/http: use `httptest.Server` for handler tests

### DIFF
--- a/pkg/agent/protocol/http/proxy_test.go
+++ b/pkg/agent/protocol/http/proxy_test.go
@@ -334,7 +334,6 @@ func Test_ProxyHandler(t *testing.T) {
 
 			handler := &httpHandler{
 				upstreamURL: *upstreamURL,
-				client:      http.DefaultClient,
 				disruption:  tc.disruption,
 				metrics:     &protocol.MetricMap{},
 			}
@@ -427,7 +426,6 @@ func Test_Metrics(t *testing.T) {
 			handler := &httpHandler{
 				upstreamURL: *upstreamURL,
 				disruption:  tc.config,
-				client:      http.DefaultClient,
 				metrics:     &metrics,
 			}
 

--- a/pkg/agent/protocol/http/proxy_test.go
+++ b/pkg/agent/protocol/http/proxy_test.go
@@ -323,7 +323,7 @@ func Test_ProxyHandler(t *testing.T) {
 
 				_, err := rw.Write(tc.upstreamBody)
 				if err != nil {
-					t.Errorf("writing upstream body: %v", err)
+					t.Fatalf("writing upstream body: %v", err)
 				}
 			}))
 
@@ -351,8 +351,7 @@ func Test_ProxyHandler(t *testing.T) {
 			}
 
 			if tc.expectedStatus != resp.StatusCode {
-				t.Errorf("expected status code '%d' but '%d' received ", tc.expectedStatus, resp.StatusCode)
-				return
+				t.Fatalf("expected status code '%d' but '%d' received ", tc.expectedStatus, resp.StatusCode)
 			}
 
 			// Remove standard response headers so we don't need to specify them on every test case.
@@ -364,15 +363,14 @@ func Test_ProxyHandler(t *testing.T) {
 			// We have to check for length explicitly as otherwise a nil map would not be equal to an empty map.
 			if len(tc.upstreamHeaders) > 0 || len(tc.expectedHeaders) > 0 {
 				if diff := cmp.Diff(tc.expectedHeaders, resp.Header); diff != "" {
-					t.Errorf("Expected headers did not match returned:\n%s", diff)
+					t.Fatalf("Expected headers did not match returned:\n%s", diff)
 				}
 			}
 
 			var body bytes.Buffer
 			_, _ = io.Copy(&body, resp.Body)
 			if !bytes.Equal(tc.expectedBody, body.Bytes()) {
-				t.Errorf("expected body '%s' but '%s' received ", tc.expectedBody, body.Bytes())
-				return
+				t.Fatalf("expected body '%s' but '%s' received ", tc.expectedBody, body.Bytes())
 			}
 		})
 	}


### PR DESCRIPTION
# Description

Fixes #305 

This PR makes minor changes to http proxy handler tests so they are performed with `httptest.Server` instead of the fake client. This aligns existing tests with the newly added metric tests, and provides more coverage as implementation details of the whole Go HTTP stack is tested, instead of just the handler.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works.   
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make test`) and all tests pass.
- [ ] I have run relevant e2e test locally (`make e2e-xxx` for `agent`, `disruptors`, `kubernetes` or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
