### PR TITLE
controller: fix test not checking expected commands for expected errors

### DIFF
--- a/pkg/disruptors/controller_test.go
+++ b/pkg/disruptors/controller_test.go
@@ -166,9 +166,10 @@ func Test_VisitPod(t *testing.T) {
 					Build(),
 			},
 			visitCmds: VisitCommands{
-				Exec:    []string{"echo", "-n", "hello", "world"},
+				Exec:    []string{"command"},
 				Cleanup: []string{"cleanup"},
-			}, err: fmt.Errorf("fake error"),
+			},
+			err:         fmt.Errorf("fake error"),
 			stderr:      []byte("error output"),
 			expectError: true,
 			expected: []helpers.Command{
@@ -209,21 +210,21 @@ func Test_VisitPod(t *testing.T) {
 				return tc.visitCmds, nil
 			})
 			if tc.expectError && err == nil {
-				t.Errorf("should had failed")
-				return
+				t.Fatalf("should had failed")
 			}
 
 			if !tc.expectError && err != nil {
-				t.Errorf("failed: %v", err)
-				return
+				t.Fatalf("failed unexpectedly: %v", err)
 			}
 
 			if tc.expectError && err != nil {
 				if !strings.Contains(err.Error(), string(tc.stderr)) {
-					t.Errorf("invalid error message. Expected to contain %s", string(tc.stderr))
+					t.Fatalf("returned error message should contain stderr (%q)", string(tc.stderr))
 				}
-				return
 			}
+
+			// At this point, we either expected no error and got no error, or we got the error we expected.
+			// In either case, we check the expected commands have been executed.
 
 			sort.Slice(tc.expected, func(i, j int) bool {
 				return tc.expected[i].Pod < tc.expected[j].Pod


### PR DESCRIPTION
# Description

Before this PR, the tests for controller were not checking the output commands if the controller returned an _expected_ error.

This PR fixes this.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make test`) and all tests pass.
- [ ] I have run relevant e2e test locally (`make e2e-xxx` for `agent`, `disruptors`, `kubernetes` or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
