### PR TITLE
agent/metrics: allow preinitializing supported metrics to zero

### DIFF
--- a/pkg/agent/protocol/grpc/proxy.go
+++ b/pkg/agent/protocol/grpc/proxy.go
@@ -80,7 +80,11 @@ func NewProxy(c ProxyConfig, d Disruption) (protocol.Proxy, error) {
 	return &proxy{
 		disruption: d,
 		config:     c,
-		metrics:    &protocol.MetricMap{},
+		metrics: protocol.NewMetricMap(
+			protocol.MetricRequests,
+			protocol.MetricRequestsExcluded,
+			protocol.MetricRequestsDisrupted,
+		),
 	}, nil
 }
 

--- a/pkg/agent/protocol/http/proxy_test.go
+++ b/pkg/agent/protocol/http/proxy_test.go
@@ -335,7 +335,7 @@ func Test_ProxyHandler(t *testing.T) {
 			handler := &httpHandler{
 				upstreamURL: *upstreamURL,
 				disruption:  tc.disruption,
-				metrics:     &protocol.MetricMap{},
+				metrics:     protocol.NewMetricMap(supportedMetrics()...),
 			}
 
 			proxyServer := httptest.NewServer(handler)
@@ -388,8 +388,12 @@ func Test_Metrics(t *testing.T) {
 		expectedMetrics map[string]uint
 	}{
 		{
-			name:            "no requests",
-			expectedMetrics: map[string]uint{},
+			name: "no requests",
+			expectedMetrics: map[string]uint{
+				protocol.MetricRequests:          0,
+				protocol.MetricRequestsExcluded:  0,
+				protocol.MetricRequestsDisrupted: 0,
+			},
 		},
 		{
 			name: "requests",
@@ -419,12 +423,12 @@ func Test_Metrics(t *testing.T) {
 				t.Fatalf("error parsing httptest url")
 			}
 
-			metrics := protocol.MetricMap{}
+			metrics := protocol.NewMetricMap(supportedMetrics()...)
 
 			handler := &httpHandler{
 				upstreamURL: *upstreamURL,
 				disruption:  tc.config,
-				metrics:     &metrics,
+				metrics:     metrics,
 			}
 
 			proxyServer := httptest.NewServer(handler)

--- a/pkg/agent/protocol/metricmap.go
+++ b/pkg/agent/protocol/metricmap.go
@@ -8,14 +8,24 @@ type MetricMap struct {
 	mutex   sync.RWMutex
 }
 
-// Inc increases the value of the specified counter by one.
+// NewMetricMap returns a MetricMap with the specified metrics initialized to zero.
+func NewMetricMap(metrics ...string) *MetricMap {
+	mm := &MetricMap{
+		metrics: map[string]uint{},
+	}
+
+	for _, metric := range metrics {
+		mm.metrics[metric] = 0
+	}
+
+	return mm
+}
+
+// Inc increases the value of the specified counter by one. If the metric hasn't been initialized or incremented before,
+// it is set to 1.
 func (m *MetricMap) Inc(name string) {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
-
-	if m.metrics == nil {
-		m.metrics = make(map[string]uint)
-	}
 
 	m.metrics[name]++
 }

--- a/pkg/agent/protocol/metricmap_test.go
+++ b/pkg/agent/protocol/metricmap_test.go
@@ -9,18 +9,34 @@ import (
 func TestMetricMap(t *testing.T) {
 	t.Parallel()
 
+	t.Run("initializes metrics", func(t *testing.T) {
+		t.Parallel()
+
+		const foo = "foo_metric"
+
+		mm := protocol.NewMetricMap(foo)
+		fooMetric, hasFoo := mm.Map()[foo]
+		if !hasFoo {
+			t.Fatalf("foo should exist in the output map")
+		}
+
+		if fooMetric != 0 {
+			t.Fatalf("foo should be zero")
+		}
+	})
+
 	t.Run("increases counters", func(t *testing.T) {
 		t.Parallel()
 
-		const name = "foo_metric"
+		const foo = "foo_metric"
 
-		mm := protocol.MetricMap{}
-		if current := mm.Map(); current[name] != 0 {
-			t.Fatalf("map should start containing zero")
+		mm := protocol.NewMetricMap()
+		if current := mm.Map(); current[foo] != 0 {
+			t.Fatalf("uninitialized foo should be zero")
 		}
 
-		mm.Inc(name)
-		if updated := mm.Map(); updated[name] != 1 {
+		mm.Inc(foo)
+		if updated := mm.Map(); updated[foo] != 1 {
 			t.Fatalf("metric was not incremented")
 		}
 	})

--- a/pkg/agent/protocol/protocol.go
+++ b/pkg/agent/protocol/protocol.go
@@ -30,7 +30,8 @@ type Proxy interface {
 	Start() error
 	Stop() error
 	// Metrics returns a map of counter-type metrics. Implementations may return zero or more of the metrics defined
-	// below, as well as any number of implementation-defined metrics.
+	// below, as well as any number of implementation-defined metrics. Callers can check if a metric exists in the map
+	// returned by Metrics to distinguish a counter with a value of zero from an unsupported metric.
 	Metrics() map[string]uint
 	Force() error
 }


### PR DESCRIPTION
# Description

With the introduction of metrics in #213, we missed an important misbehavior: If a proxy never calls `Inc` on a metric, it is impossible to tell whether the metric is zero, or is not supported by the proxy. To fix this, this PR give proxies the ability to pre-initialize supported metrics to zero.

This PR also introduces a workaround: As the HTTP proxy is not directly testable, the handler is, the test for the handler needs to duplicate this initialization. This workaround should be removed when testing for the HTTP proxy is improved.

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works.   
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make test`) and all tests pass.
- [ ] I have run relevant e2e test locally (`make e2e-xxx` for `agent`, `disruptors`, `kubernetes` or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
