### PR TITLE
Add tool for e2e test cluster setup and cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ build: test
 	go install go.k6.io/xk6/cmd/xk6@latest
 	xk6 build --with $(shell go list -m)=. --output build/k6
 
+build-e2e:
+	go build -tags e2e -o build/e2e-cluster ./cmd/e2e/main.go
+
 build-agent:
 	GOOS=linux CGO_ENABLED=0 go build -o images/agent/build/xk6-disruptor-agent-linux-${arch} ./cmd/agent
 

--- a/cmd/e2e-cluster/commands/cleanup.go
+++ b/cmd/e2e-cluster/commands/cleanup.go
@@ -1,0 +1,30 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/grafana/xk6-disruptor/pkg/testutils/e2e/cluster"
+	"github.com/spf13/cobra"
+)
+
+// BuildCleanupCmd returns the cleanup command
+func BuildCleanupCmd() *cobra.Command {
+	var name string
+	var quiet bool
+
+	cmd := &cobra.Command{
+		Use:   "cleanup",
+		Short: "deletes an e2e test cluster ",
+		Long:  "deletes an e2e test cluster",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if name == "" {
+				return fmt.Errorf("--name is required")
+			}
+			return cluster.DeleteE2eCluster(name, quiet)
+		},
+	}
+
+	cmd.Flags().StringVarP(&name, "name", "n", "", "name of the cluster to delete. Required")
+	cmd.Flags().BoolVarP(&quiet, "quiet", "q", false, "do not report error if cluster does not exist")
+	return cmd
+}

--- a/cmd/e2e-cluster/commands/doc.go
+++ b/cmd/e2e-cluster/commands/doc.go
@@ -1,0 +1,2 @@
+// Package commands implements the CLI interface for the e2e env CLI tool
+package commands

--- a/cmd/e2e-cluster/commands/root.go
+++ b/cmd/e2e-cluster/commands/root.go
@@ -1,0 +1,18 @@
+package commands
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// BuildRootCmd returns the root command for the e2e-env cli tool
+func BuildRootCmd() *cobra.Command {
+	rootCmd := &cobra.Command{
+		Use:           "e2e-cluster",
+		Short:         "maintain e2e test clusters",
+		Long:          "A command for the setup and cleanup of e2e test clusters.",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+
+	return rootCmd
+}

--- a/cmd/e2e-cluster/commands/setup.go
+++ b/cmd/e2e-cluster/commands/setup.go
@@ -10,6 +10,7 @@ import (
 // BuildSetupCmd returns the setup command
 func BuildSetupCmd() *cobra.Command {
 	name := cluster.DefaultE2eClusterConfig().Name
+	port := cluster.DefaultE2eClusterConfig().IngressPort
 
 	cmd := &cobra.Command{
 		Use:   "setup",
@@ -20,6 +21,7 @@ func BuildSetupCmd() *cobra.Command {
 				cluster.DefaultE2eClusterConfig(),
 				cluster.WithEnvOverride(false),
 				cluster.WithName(name),
+				cluster.WithIngressPort(port),
 			)
 			if err != nil {
 				return fmt.Errorf("failed to create cluster: %w", err)
@@ -32,6 +34,7 @@ func BuildSetupCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&name, "name", "n", name, "name of the cluster")
+	cmd.Flags().Int32VarP(&port, "port", "p", port, "ingress port")
 
 	return cmd
 }

--- a/cmd/e2e-cluster/commands/setup.go
+++ b/cmd/e2e-cluster/commands/setup.go
@@ -11,6 +11,7 @@ import (
 func BuildSetupCmd() *cobra.Command {
 	name := cluster.DefaultE2eClusterConfig().Name
 	port := cluster.DefaultE2eClusterConfig().IngressPort
+	var images []string
 
 	cmd := &cobra.Command{
 		Use:   "setup",
@@ -22,6 +23,7 @@ func BuildSetupCmd() *cobra.Command {
 				cluster.WithEnvOverride(false),
 				cluster.WithName(name),
 				cluster.WithIngressPort(port),
+				cluster.WithImages(images...),
 			)
 			if err != nil {
 				return fmt.Errorf("failed to create cluster: %w", err)
@@ -35,6 +37,8 @@ func BuildSetupCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&name, "name", "n", name, "name of the cluster")
 	cmd.Flags().Int32VarP(&port, "port", "p", port, "ingress port")
+	cmd.Flags().StringArrayVarP(&images, "image", "i", cluster.DefaultE2eClusterConfig().Images,
+		"additional image to pre-load in the cluster. Can be specified multiple times for loading multiple images.")
 
 	return cmd
 }

--- a/cmd/e2e-cluster/commands/setup.go
+++ b/cmd/e2e-cluster/commands/setup.go
@@ -18,6 +18,7 @@ func BuildSetupCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cluster, err := cluster.BuildE2eCluster(
 				cluster.DefaultE2eClusterConfig(),
+				cluster.WithEnvOverride(false),
 				cluster.WithName(name),
 			)
 			if err != nil {

--- a/cmd/e2e-cluster/commands/setup.go
+++ b/cmd/e2e-cluster/commands/setup.go
@@ -1,0 +1,36 @@
+package commands
+
+import (
+	"fmt"
+
+	"github.com/grafana/xk6-disruptor/pkg/testutils/e2e/cluster"
+	"github.com/spf13/cobra"
+)
+
+// BuildSetupCmd returns the setup command
+func BuildSetupCmd() *cobra.Command {
+	name := cluster.DefaultE2eClusterConfig().Name
+
+	cmd := &cobra.Command{
+		Use:   "setup",
+		Short: "creates and configures an e2e test cluster ",
+		Long:  "creates and configures an e2e test cluster with default options.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cluster, err := cluster.BuildE2eCluster(
+				cluster.DefaultE2eClusterConfig(),
+				cluster.WithName(name),
+			)
+			if err != nil {
+				return fmt.Errorf("failed to create cluster: %w", err)
+			}
+
+			//nolint:forbidigo // allow printf as this is a CLI tool
+			fmt.Printf("cluster %q created\n", cluster.Name())
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(&name, "name", "n", name, "name of the cluster")
+
+	return cmd
+}

--- a/cmd/e2e-cluster/main.go
+++ b/cmd/e2e-cluster/main.go
@@ -1,0 +1,20 @@
+// Package main implements the main function for the e2e environment setup tool
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/grafana/xk6-disruptor/cmd/e2e-cluster/commands"
+)
+
+func main() {
+	rootCmd := commands.BuildRootCmd()
+	rootCmd.AddCommand(commands.BuildSetupCmd())
+	rootCmd.AddCommand(commands.BuildCleanupCmd())
+
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+}

--- a/docs/01-development/01-contributing.md
+++ b/docs/01-development/01-contributing.md
@@ -196,6 +196,10 @@ func Test_E2E(t *testing.T) {
 	        t.Errorf("failed to create cluster: %v", err)
 	        return
         }
+	// delete cluster when all sub-tests end
+	t.Cleanup(func(){
+		_ = cluster.Cleanup()
+	})
 
 	// get kubernetes client
 	k8s, err := kubernetes.NewFromKubeconfig(cluster.Kubeconfig())
@@ -242,9 +246,9 @@ The port to be exposed by the test cluster can be changed using the `WithIngress
 
 ### Debugging e2e tests
 
-By default, once the e2e test is completed, the test cluster is deleted. This is inconvenient for debugging failed tests.
+In the examples above, once the e2e test is completed, the test cluster is deleted using the `Cleanup` method. This is inconvenient for debugging failed tests.
 
-This behavior is controlled by the `AutoCleanup` option in the `E2eClusterConfig`. By default it is true. This option can be disable using the `WithAutoCleanup(false)` option in the `BuildE2eCluster` function or by setting `E2E_AUTOCLEANUP=false` in your environment.
+This behavior is controlled by the `AutoCleanup` option in the `E2eClusterConfig`. By default it is true. This option can be disable using the `WithAutoCleanup(false)` option in the `BuildE2eCluster` function or by setting `E2E_AUTOCLEANUP=false` in your environment. When this option is disable, the `Cleanup` method will leave the cluster intact.
 
 ### Reusing e2e test clusters
 

--- a/docs/01-development/01-contributing.md
+++ b/docs/01-development/01-contributing.md
@@ -273,26 +273,31 @@ This behavior is controlled by passing the `WithKeepOnFail` option when creating
 
 ### e2e-cluster tool
 
-The `e2e-cluster` tool allows the setup and cleanup of e2e clusters. It is convenient for creating a cluster that will be reused by multiple tests, and clean it up when it is no longer used:
+The `e2e-cluster` tool allows the setup and cleanup of e2e clusters. It is convenient for creating a cluster that will be reused by multiple tests, and clean it up when it is no longer used. 
+
+If you plan to create more than one test cluster, you should ensure each has an unique name and also, each one uses a different port for the ingress controller service.
+
+> In order to each test to use the cluster you must set the following environment variables: `E2E_REUSE=1` and `E2E_AUTOCLEANUP=0`
 
 ```sh
 # create cluster with default options
-e2e-cluster setup
+e2e-cluster setup --name e2e-test --port 30080
 cluster 'e2e-test' created
 
 # execute tests reusing cluster, do not delete it automatically
 # override the cluster name to ensure the test reuses the cluster created above
-E2E_REUSE=1 E2E_AUTOCLEANUP=0 E2E_NAME=e2e-test go test ...
+# override the ingress port to use the one configured in the cluster
+E2E_REUSE=1 E2E_AUTOCLEANUP=0 E2E_NAME=e2e-test E2E_PORT=30080 go test ...
 
 ## cleanup
 cluster cleanup --name e2e-test
 ```
 
-The tool is create with the command `go install ./cmd/e2e-cluster` that installs the binary `e2e-cluster`
 
-It offers two main subcommands:
-* setup: creates a cluster
-* cleanup: deletes a cluster
+
+
+
+The tool is create with the command `go install ./cmd/e2e-cluster` that installs the binary `e2e-cluster`
 
 For more details, install the tool and execute `e2e-cluster --help`
 

--- a/docs/01-development/01-contributing.md
+++ b/docs/01-development/01-contributing.md
@@ -248,19 +248,19 @@ The port to be exposed by the test cluster can be changed using the `WithIngress
 
 In the examples above, once the e2e test is completed, the test cluster is deleted using the `Cleanup` method. This is inconvenient for debugging failed tests.
 
-This behavior is controlled by the `AutoCleanup` option in the `E2eClusterConfig`. By default it is true. This option can be disable using the `WithAutoCleanup(false)` option in the `BuildE2eCluster` function or by setting `E2E_AUTOCLEANUP=false` in your environment. When this option is disable, the `Cleanup` method will leave the cluster intact.
+This behavior is controlled by the `AutoCleanup` option in the `E2eClusterConfig`. By default it is true. This option can be disable using the `WithAutoCleanup(false)` option in the `BuildE2eCluster` function or by setting `E2E_AUTOCLEANUP=0` in your environment. When this option is disable, the `Cleanup` method will leave the cluster intact.
 
 ### Reusing e2e test clusters
 
 By default, each e2e test creates a new test cluster to ensure it is properly configured and prevent any left-over from previous runs to affect the test.
 
-However, when testing a solution to an issue, creating a new cluster for each test is time-consuming. 
+However, in some circumstances, creating a new cluster for each test is time-consuming.
 
-It is possible to specify that we want to reuse a test cluster is one exists with the `Reuse` option in the `E2eClusterConfig`. This option can be set with the `WithReuse` configuration option or setting the `E2E_REUSE=true` in your environment.
+It is possible to specify that we want to reuse a test cluster is one exists with the `Reuse` option in the `E2eClusterConfig`. This option can be set with the `WithReuse` configuration option or setting the `E2E_REUSE=1` in your environment.
 
 > Note: if you are testing changes in the agent, be sure you generate the image and [upload it to the cluster](#building-the-xk6-disruptor-agent-image) using kind
 
-When you don't longer needs the cluster, you can delete it using kind:
+When you don't longer needs the cluster, you can delete it using the [e2e-cluster tool](#e2e-cluster-tool) or directly `kind`:
 ```sh
 kind delete cluster --name=<cluster name>
 ```
@@ -269,4 +269,31 @@ kind delete cluster --name=<cluster name>
 
 By default, test namespaces created with `CreateTestNamespace` are automatically deleted when a test ends. This is inconvenient for debugging failed tests.
 
-This behavior is controlled by passing the `WithKeepOnFail` option when creating the namespace or by setting `E2E_KEEPONFAIL=true` in the environment when running an e2e test.
+This behavior is controlled by passing the `WithKeepOnFail` option when creating the namespace or by setting `E2E_KEEPONFAIL=1` in the environment when running an e2e test.
+
+### e2e-cluster tool
+
+The `e2e-cluster` tool allows the setup and cleanup of e2e clusters. It is convenient for creating a cluster that will be reused by multiple tests, and clean it up when it is no longer used:
+
+```sh
+# create cluster with default options
+e2e-cluster setup
+cluster 'e2e-test' created
+
+# execute tests reusing cluster, do not delete it automatically
+# override the cluster name to ensure the test reuses the cluster created above
+E2E_REUSE=1 E2E_AUTOCLEANUP=0 E2E_NAME=e2e-test go test ...
+
+## cleanup
+cluster cleanup --name e2e-test
+```
+
+The tool is create with the command `go install ./cmd/e2e-cluster` that installs the binary `e2e-cluster`
+
+It offers two main subcommands:
+* setup: creates a cluster
+* cleanup: deletes a cluster
+
+For more details, install the tool and execute `e2e-cluster --help`
+
+

--- a/docs/01-development/01-contributing.md
+++ b/docs/01-development/01-contributing.md
@@ -256,11 +256,12 @@ By default, each e2e test creates a new test cluster to ensure it is properly co
 
 However, in some circumstances, creating a new cluster for each test is time-consuming.
 
-It is possible to specify that we want to reuse a test cluster is one exists with the `Reuse` option in the `E2eClusterConfig`. This option can be set with the `WithReuse` configuration option or setting the `E2E_REUSE=1` in your environment.
+It is possible to specify that we want to reuse a test cluster if one exists using the `Reuse` option in the `E2eClusterConfig`. This option can be set with the `WithReuse` configuration option or setting the `E2E_REUSE=1` in your environment. Notice that `WithReuse(true)` forces `WithAutoCleanup(false)` as a reused cluster should be preserved until explicitly deleted.
 
 > Note: if you are testing changes in the agent, be sure you generate the image and [upload it to the cluster](#building-the-xk6-disruptor-agent-image) using kind
 
-When you don't longer needs the cluster, you can delete it using the [e2e-cluster tool](#e2e-cluster-tool) or directly `kind`:
+When you don't longer needs the cluster, you can delete it using the [e2e-cluster tool](#e2e-cluster-tool) or `kind`:
+
 ```sh
 kind delete cluster --name=<cluster name>
 ```
@@ -277,27 +278,23 @@ The `e2e-cluster` tool allows the setup and cleanup of e2e clusters. It is conve
 
 If you plan to create more than one test cluster, you should ensure each has an unique name and also, each one uses a different port for the ingress controller service.
 
-> In order to each test to use the cluster you must set the following environment variables: `E2E_REUSE=1` and `E2E_AUTOCLEANUP=0`
+> In order to each test to use the cluster you must set `E2E_REUSE=1` in the environment variables.
 
 ```sh
 # create cluster with default options
 e2e-cluster setup --name e2e-test --port 30080
 cluster 'e2e-test' created
 
-# execute tests reusing cluster, do not delete it automatically
+# execute tests reusing cluster
 # override the cluster name to ensure the test reuses the cluster created above
 # override the ingress port to use the one configured in the cluster
-E2E_REUSE=1 E2E_AUTOCLEANUP=0 E2E_NAME=e2e-test E2E_PORT=30080 go test ...
+E2E_REUSE=1 E2E_NAME=e2e-test E2E_PORT=30080 go test ...
 
 ## cleanup
 cluster cleanup --name e2e-test
 ```
 
-
-
-
-
-The tool is create with the command `go install ./cmd/e2e-cluster` that installs the binary `e2e-cluster`
+This tool is create with the command `go install ./cmd/e2e-cluster` that installs the binary `e2e-cluster`
 
 For more details, install the tool and execute `e2e-cluster --help`
 

--- a/e2e/agent/agent_e2e_test.go
+++ b/e2e/agent/agent_e2e_test.go
@@ -165,7 +165,6 @@ func builDisruptorService() corev1.Service {
 
 func Test_Agent(t *testing.T) {
 	cluster, err := cluster.BuildE2eCluster(
-		t,
 		cluster.DefaultE2eClusterConfig(),
 		cluster.WithName("e2e-xk6-agent"),
 		cluster.WithIngressPort(30080),
@@ -174,6 +173,9 @@ func Test_Agent(t *testing.T) {
 		t.Errorf("failed to create e2e cluster: %v", err)
 		return
 	}
+	t.Cleanup(func() {
+		_ = cluster.Cleanup()
+	})
 
 	k8s, err := kubernetes.NewFromKubeconfig(cluster.Kubeconfig())
 	if err != nil {

--- a/e2e/cluster/cluster_e2e_test.go
+++ b/e2e/cluster/cluster_e2e_test.go
@@ -230,3 +230,64 @@ func Test_GetCluster(t *testing.T) {
 		return
 	}
 }
+
+func Test_DeleteCluster(t *testing.T) {
+	// create cluster with  configuration
+	config, err := cluster.NewConfig(
+		"existing-cluster",
+		cluster.Options{
+			Wait: time.Second * 30,
+		},
+	)
+	if err != nil {
+		t.Errorf("failed creating cluster configuration: %v", err)
+		return
+	}
+
+	_, err = config.Create()
+	if err != nil {
+		t.Errorf("failed to create cluster: %v", err)
+		return
+	}
+
+	testCases := []struct {
+		test        string
+		name        string
+		quiet       bool
+		expectError bool
+	}{
+		{
+			test:        "delete existing cluster",
+			name:        "existing-cluster",
+			quiet:       false,
+			expectError: false,
+		},
+		{
+			test:        "delete non-existing cluster",
+			name:        "non-existing-cluster",
+			quiet:       false,
+			expectError: true,
+		},
+		{
+			test:        "delete non-existing cluster with quiet option",
+			name:        "non-existing-cluster",
+			quiet:       true,
+			expectError: false,
+		},
+	}
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			err = cluster.DeleteCluster(tc.name, tc.quiet)
+			if err != nil && !tc.expectError {
+				t.Fatalf("failed deleting cluster: %v", err)
+			}
+
+			if err == nil && tc.expectError {
+				t.Fatalf("should had failed deleting cluster")
+			}
+		})
+	}
+
+}

--- a/e2e/disruptors/pod_e2e_test.go
+++ b/e2e/disruptors/pod_e2e_test.go
@@ -24,7 +24,6 @@ func Test_PodDisruptor(t *testing.T) {
 	t.Parallel()
 
 	cluster, err := cluster.BuildE2eCluster(
-		t,
 		cluster.DefaultE2eClusterConfig(),
 		cluster.WithName("e2e-pod-disruptor"),
 		cluster.WithIngressPort(30082),
@@ -33,6 +32,9 @@ func Test_PodDisruptor(t *testing.T) {
 		t.Errorf("failed to create cluster: %v", err)
 		return
 	}
+	t.Cleanup(func() {
+		_ = cluster.Cleanup()
+	})
 
 	k8s, err := kubernetes.NewFromKubeconfig(cluster.Kubeconfig())
 	if err != nil {
@@ -52,10 +54,10 @@ func Test_PodDisruptor(t *testing.T) {
 			check    checks.Check
 		}{
 			{
-				title:    "Inject Http error 500",
-				pod:      fixtures.BuildHttpbinPod(),
-				service:  fixtures.BuildHttpbinService(),
-				port:     80,
+				title:   "Inject Http error 500",
+				pod:     fixtures.BuildHttpbinPod(),
+				service: fixtures.BuildHttpbinService(),
+				port:    80,
 				injector: func(d disruptors.PodDisruptor) error {
 					fault := disruptors.HTTPFault{
 						Port:      80,
@@ -89,7 +91,7 @@ func Test_PodDisruptor(t *testing.T) {
 						StatusCode: 14,
 						Exclude:    "grpc.reflection.v1alpha.ServerReflection,grpc.reflection.v1.ServerReflection",
 					}
-					options:= disruptors.GrpcDisruptionOptions{
+					options := disruptors.GrpcDisruptionOptions{
 						ProxyPort: 3000,
 					}
 

--- a/e2e/disruptors/service_e2e_test.go
+++ b/e2e/disruptors/service_e2e_test.go
@@ -18,12 +18,10 @@ import (
 	"github.com/grafana/xk6-disruptor/pkg/testutils/e2e/deploy"
 	"github.com/grafana/xk6-disruptor/pkg/testutils/e2e/fixtures"
 	"github.com/grafana/xk6-disruptor/pkg/testutils/e2e/kubernetes/namespace"
-
 )
 
 func Test_ServiceDisruptor(t *testing.T) {
 	cluster, err := cluster.BuildE2eCluster(
-		t,
 		cluster.DefaultE2eClusterConfig(),
 		cluster.WithName("e2e-service-disruptor"),
 		cluster.WithIngressPort(30083),
@@ -32,6 +30,9 @@ func Test_ServiceDisruptor(t *testing.T) {
 		t.Errorf("failed to create cluster: %v", err)
 		return
 	}
+	t.Cleanup(func() {
+		_ = cluster.Cleanup()
+	})
 
 	k8s, err := kubernetes.NewFromKubeconfig(cluster.Kubeconfig())
 	if err != nil {
@@ -51,10 +52,10 @@ func Test_ServiceDisruptor(t *testing.T) {
 			check    checks.Check
 		}{
 			{
-				title:    "Inject Http error 500",
-				pod:      fixtures.BuildHttpbinPod(),
-				service:  fixtures.BuildHttpbinService(),
-				port:     80,
+				title:   "Inject Http error 500",
+				pod:     fixtures.BuildHttpbinPod(),
+				service: fixtures.BuildHttpbinService(),
+				port:    80,
 				injector: func(d disruptors.ServiceDisruptor) error {
 					fault := disruptors.HTTPFault{
 						Port:      80,
@@ -103,7 +104,7 @@ func Test_ServiceDisruptor(t *testing.T) {
 				options := disruptors.ServiceDisruptorOptions{}
 				disruptor, err := disruptors.NewServiceDisruptor(
 					context.TODO(),
-					k8s, 
+					k8s,
 					tc.service.Name,
 					namespace,
 					options,

--- a/e2e/kubernetes/kubernetes_e2e_test.go
+++ b/e2e/kubernetes/kubernetes_e2e_test.go
@@ -22,7 +22,6 @@ import (
 
 func Test_Kubernetes(t *testing.T) {
 	cluster, err := cluster.BuildE2eCluster(
-		t,
 		cluster.DefaultE2eClusterConfig(),
 		cluster.WithName("e2e-kubernetes"),
 		cluster.WithIngressPort(30081),
@@ -31,6 +30,9 @@ func Test_Kubernetes(t *testing.T) {
 		t.Errorf("failed to create cluster: %v", err)
 		return
 	}
+	t.Cleanup(func() {
+		_ = cluster.Cleanup()
+	})
 
 	k8s, err := kubernetes.NewFromKubeconfig(cluster.Kubeconfig())
 	if err != nil {

--- a/pkg/testutils/e2e/cluster/cluster.go
+++ b/pkg/testutils/e2e/cluster/cluster.go
@@ -30,6 +30,7 @@ type E2eClusterConfig struct {
 	AutoCleanup    bool
 	Kubeconfig     string
 	UseEtcdRAMDisk bool
+	EnvOverride    bool
 }
 
 // E2eCluster defines the interface for accessing an e2e cluster
@@ -119,6 +120,7 @@ func DefaultE2eClusterConfig() E2eClusterConfig {
 			InstallContourIngress,
 		},
 		UseEtcdRAMDisk: true,
+		EnvOverride:    true,
 	}
 }
 
@@ -189,6 +191,14 @@ func WithEtcdRAMDisk(ramdisk bool) E2eClusterOption {
 	}
 }
 
+// WithEnvOverride specifies if the cluster configuration can be overridden by environment variables
+func WithEnvOverride(override bool) E2eClusterOption {
+	return func(c E2eClusterConfig) (E2eClusterConfig, error) {
+		c.EnvOverride = override
+		return c, nil
+	}
+}
+
 // e2eCluster maintains the status of a cluster
 type e2eCluster struct {
 	cluster     *cluster.Cluster
@@ -248,6 +258,9 @@ func createE2eCluster(e2eConfig E2eClusterConfig) (*e2eCluster, error) {
 
 // merge options from environment variables
 func mergeEnvVariables(config E2eClusterConfig) E2eClusterConfig {
+	if !config.EnvOverride {
+		return config
+	}
 	config.AutoCleanup = utils.GetBooleanEnvVar("E2E_AUTOCLEANUP", config.AutoCleanup)
 	config.Reuse = utils.GetBooleanEnvVar("E2E_REUSE", config.Reuse)
 	config.UseEtcdRAMDisk = utils.GetBooleanEnvVar("E2E_ETCD_RAMDISK", config.UseEtcdRAMDisk)

--- a/pkg/testutils/e2e/cluster/cluster.go
+++ b/pkg/testutils/e2e/cluster/cluster.go
@@ -200,6 +200,14 @@ func WithEnvOverride(override bool) E2eClusterOption {
 	}
 }
 
+// WithImages adds images to the list of images to be pre-loaded into the cluster
+func WithImages(images ...string) E2eClusterOption {
+	return func(c E2eClusterConfig) (E2eClusterConfig, error) {
+		c.Images = append(c.Images, images...)
+		return c, nil
+	}
+}
+
 // e2eCluster maintains the status of a cluster
 type e2eCluster struct {
 	cluster     *cluster.Cluster

--- a/pkg/testutils/e2e/cluster/cluster.go
+++ b/pkg/testutils/e2e/cluster/cluster.go
@@ -251,6 +251,7 @@ func mergeEnvVariables(config E2eClusterConfig) E2eClusterConfig {
 	config.AutoCleanup = utils.GetBooleanEnvVar("E2E_AUTOCLEANUP", config.AutoCleanup)
 	config.Reuse = utils.GetBooleanEnvVar("E2E_REUSE", config.Reuse)
 	config.UseEtcdRAMDisk = utils.GetBooleanEnvVar("E2E_ETCD_RAMDISK", config.UseEtcdRAMDisk)
+	config.Name = utils.GetStringEnvVar("E2E_NAME", config.Name)
 	return config
 }
 

--- a/pkg/testutils/e2e/cluster/cluster.go
+++ b/pkg/testutils/e2e/cluster/cluster.go
@@ -176,6 +176,7 @@ func WithAutoCleanup(autoCleanup bool) E2eClusterOption {
 }
 
 // WithReuse specifies if an existing cluster with the same name must be reused (true) or deleted (false)
+// WithReuse(true) implies WithAutoCleanup(false)
 func WithReuse(reuse bool) E2eClusterOption {
 	return func(c E2eClusterConfig) (E2eClusterConfig, error) {
 		c.Reuse = reuse
@@ -299,7 +300,7 @@ func BuildE2eCluster(
 				cluster:     c,
 				ingress:     ingress,
 				name:        e2eConfig.Name,
-				autoCleanup: e2eConfig.AutoCleanup,
+				autoCleanup: false, // reuse implies no auto-cleanup
 			}, nil
 		}
 

--- a/pkg/testutils/e2e/cluster/cluster.go
+++ b/pkg/testutils/e2e/cluster/cluster.go
@@ -265,6 +265,7 @@ func mergeEnvVariables(config E2eClusterConfig) E2eClusterConfig {
 	config.Reuse = utils.GetBooleanEnvVar("E2E_REUSE", config.Reuse)
 	config.UseEtcdRAMDisk = utils.GetBooleanEnvVar("E2E_ETCD_RAMDISK", config.UseEtcdRAMDisk)
 	config.Name = utils.GetStringEnvVar("E2E_NAME", config.Name)
+	config.IngressPort = utils.GetInt32EnvVar("E2E_PORT", config.IngressPort)
 	return config
 }
 

--- a/pkg/testutils/e2e/cluster/cluster.go
+++ b/pkg/testutils/e2e/cluster/cluster.go
@@ -305,6 +305,11 @@ func BuildDefaultE2eCluster() (E2eCluster, error) {
 	return BuildE2eCluster(DefaultE2eClusterConfig())
 }
 
+// DeleteE2eCluster deletes an existing e2e cluster
+func DeleteE2eCluster(name string, quiet bool) error {
+	return cluster.DeleteCluster(name, quiet)
+}
+
 func (c *e2eCluster) Cleanup() error {
 	if !c.autoCleanup {
 		return nil

--- a/pkg/utils/env.go
+++ b/pkg/utils/env.go
@@ -14,3 +14,13 @@ func GetBooleanEnvVar(envVar string, defaultValue bool) bool {
 	}
 	return value
 }
+
+// GetStringEnvVar returns a string environment variable.
+// If variable is not set returns the default value
+func GetStringEnvVar(envVar string, defaultValue string) string {
+	name := os.Getenv(envVar)
+	if name == "" {
+		return defaultValue
+	}
+	return name
+}

--- a/pkg/utils/env.go
+++ b/pkg/utils/env.go
@@ -24,3 +24,13 @@ func GetStringEnvVar(envVar string, defaultValue string) string {
 	}
 	return name
 }
+
+// GetInt32EnvVar returns an integer environment variable.
+// If variable is not set or invalid value, returns the default value
+func GetInt32EnvVar(envVar string, defaultValue int32) int32 {
+	value, err := strconv.ParseInt(os.Getenv(envVar), 0, 32)
+	if err != nil {
+		return defaultValue
+	}
+	return int32(value)
+}


### PR DESCRIPTION
# Description

Fixes https://github.com/grafana/xk6-disruptor/issues/311

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works.   
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make test`) and all tests pass.
- [ ] I have run relevant e2e test locally (`make e2e-xxx` for `agent`, `disruptors`, `kubernetes` or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
