### PR TITLE
Apply fault injection validations uniformly

### DIFF
--- a/pkg/disruptors/pod.go
+++ b/pkg/disruptors/pod.go
@@ -150,6 +150,10 @@ func (d *podDisruptor) InjectGrpcFaults(
 			return VisitCommands{}, fmt.Errorf("pod %q does not expose port %d", pod.Name, fault.Port)
 		}
 
+		if utils.HasHostNetwork(pod) {
+			return VisitCommands{}, fmt.Errorf("pod %q cannot be safely injected as it has hostNetwork set to true", pod.Name)
+		}
+
 		targetAddress, err := utils.PodIP(pod)
 		if err != nil {
 			return VisitCommands{}, err

--- a/pkg/disruptors/service.go
+++ b/pkg/disruptors/service.go
@@ -93,15 +93,14 @@ func (d *serviceDisruptor) InjectHTTPFaults(
 			return VisitCommands{}, fmt.Errorf("pod %q cannot be safely injected as it has hostNetwork set to true", pod.Name)
 		}
 
-		// copy fault to change target port for the pod
-		podFault := fault
-		podFault.Port = port
-
 		targetAddress, err := utils.PodIP(pod)
 		if err != nil {
 			return VisitCommands{}, err
 		}
 
+		// copy fault to change target port for the pod
+		podFault := fault
+		podFault.Port = port
 		visitCommands := VisitCommands{
 			Exec:    buildHTTPFaultCmd(targetAddress, podFault, duration, options),
 			Cleanup: buildCleanupCmd(),
@@ -125,14 +124,18 @@ func (d *serviceDisruptor) InjectGrpcFaults(
 			return VisitCommands{}, err
 		}
 
-		podFault := fault
-		podFault.Port = port
+		if utils.HasHostNetwork(pod) {
+			return VisitCommands{}, fmt.Errorf("pod %q cannot be safely injected as it has hostNetwork set to true", pod.Name)
+		}
 
 		targetAddress, err := utils.PodIP(pod)
 		if err != nil {
 			return VisitCommands{}, err
 		}
 
+		// copy fault to change target port for the pod
+		podFault := fault
+		podFault.Port = port
 		visitCommands := VisitCommands{
 			Exec:    buildGrpcFaultCmd(targetAddress, podFault, duration, options),
 			Cleanup: buildCleanupCmd(),


### PR DESCRIPTION
# Description
Apply relevant validations in all fault injection methods in Pod and Service disruptors across protocols (HTTP, GRPC)

Fixes #299 

# Checklist:

- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [X] I have run linter locally (`make lint`) and all checks pass.
- [X] I have run tests locally (`make test`) and all tests pass.
- [X] I have run relevant e2e test locally (`make e2e-xxx` for `agent`, `disruptors`, `kubernetes` or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
