### PR TITLE
Use default options in all e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ build: test
 	xk6 build --with $(shell go list -m)=. --output build/k6
 
 build-e2e:
-	go build -tags e2e -o build/e2e-cluster ./cmd/e2e/main.go
+	go build -tags e2e -o build/e2e-cluster ./cmd/e2e-cluster/main.go
 
 build-agent:
 	GOOS=linux CGO_ENABLED=0 go build -o images/agent/build/xk6-disruptor-agent-linux-${arch} ./cmd/agent
@@ -26,20 +26,20 @@ build-agent:
 clean:
 	rm -rf image/agent/build build/
 	
-e2e-disruptors: agent-image
-	go test -tags e2e ./e2e/disruptors/...
+e2e-disruptors: agent-image e2e-setup
+	E2E_REUSE=1 go test -tags e2e ./e2e/disruptors/...
 
 e2e-cluster:
 	go test -tags e2e ./e2e/cluster/...
 
-e2e-agent: agent-image
-	go test -tags e2e ./e2e/agent/...
+e2e-agent: agent-image e2e-setup
+	E2E_REUSE=1 go test -tags e2e ./e2e/agent/...
 
 e2e-kubernetes:
 	go test -tags e2e ./e2e/kubernetes/...
 
-e2e:
-	go test -tags e2e ./e2e/...
+e2e-setup: build-e2e
+	build/e2e-cluster setup
 
 format:
 	go fmt ./...
@@ -52,4 +52,3 @@ lint:
 test:
 	go test -race  ./...
 
-.PHONY: agent-image build build-agent clean e2e e2e-disruptors e2e-cluster e2e-agent e2e-kubernetes format lint test

--- a/docs/01-development/01-contributing.md
+++ b/docs/01-development/01-contributing.md
@@ -282,16 +282,30 @@ If you plan to create more than one test cluster, you should ensure each has an 
 
 ```sh
 # create cluster with default options
-e2e-cluster setup --name e2e-test --port 30080
+e2e-cluster setup
 cluster 'e2e-test' created
 
-# execute tests reusing cluster
-# override the cluster name to ensure the test reuses the cluster created above
-# override the ingress port to use the one configured in the cluster
-E2E_REUSE=1 E2E_NAME=e2e-test E2E_PORT=30080 go test ...
+# execute tests reusing the cluster
+E2E_REUSE=1 go test ...
 
 ## cleanup
-cluster cleanup --name e2e-test
+cluster cleanup
+```
+
+It is also possible to create multiple test clusters and use them for different tests. In this case, it is important to remember setting the environment variables to override default options in the tests:
+
+```sh
+# create cluster with non-default options
+e2e-cluster setup --name other-e2e-cluster --port 30090
+cluster 'other-e2e-cluster' created
+
+# execute tests reusing the cluster
+# override the cluster name to ensure the test reuses the cluster created above
+# override the ingress port to use the one configured in the cluster
+E2E_REUSE=1 E2E_NAME=other-e2e-cluster E2E_PORT=30090 go test ...
+
+## cleanup
+cluster cleanup --name other-e2e-cluster
 ```
 
 This tool is create with the command `go install ./cmd/e2e-cluster` that installs the binary `e2e-cluster`

--- a/e2e/agent/agent_e2e_test.go
+++ b/e2e/agent/agent_e2e_test.go
@@ -164,10 +164,10 @@ func builDisruptorService() corev1.Service {
 }
 
 func Test_Agent(t *testing.T) {
+	t.Parallel()
+
 	cluster, err := cluster.BuildE2eCluster(
 		cluster.DefaultE2eClusterConfig(),
-		cluster.WithName("e2e-xk6-agent"),
-		cluster.WithIngressPort(30080),
 	)
 	if err != nil {
 		t.Errorf("failed to create e2e cluster: %v", err)

--- a/e2e/cluster/cluster_e2e_test.go
+++ b/e2e/cluster/cluster_e2e_test.go
@@ -278,5 +278,4 @@ func Test_DeleteCluster(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/e2e/disruptors/pod_e2e_test.go
+++ b/e2e/disruptors/pod_e2e_test.go
@@ -25,8 +25,6 @@ func Test_PodDisruptor(t *testing.T) {
 
 	cluster, err := cluster.BuildE2eCluster(
 		cluster.DefaultE2eClusterConfig(),
-		cluster.WithName("e2e-pod-disruptor"),
-		cluster.WithIngressPort(30082),
 	)
 	if err != nil {
 		t.Errorf("failed to create cluster: %v", err)

--- a/e2e/disruptors/service_e2e_test.go
+++ b/e2e/disruptors/service_e2e_test.go
@@ -21,10 +21,10 @@ import (
 )
 
 func Test_ServiceDisruptor(t *testing.T) {
+	t.Parallel()
+
 	cluster, err := cluster.BuildE2eCluster(
 		cluster.DefaultE2eClusterConfig(),
-		cluster.WithName("e2e-service-disruptor"),
-		cluster.WithIngressPort(30083),
 	)
 	if err != nil {
 		t.Errorf("failed to create cluster: %v", err)

--- a/e2e/kubectl/kubectl_e2e_test.go
+++ b/e2e/kubectl/kubectl_e2e_test.go
@@ -20,10 +20,10 @@ import (
 )
 
 func Test_Kubectl(t *testing.T) {
+	t.Parallel()
+
 	cluster, err := cluster.BuildE2eCluster(
 		cluster.DefaultE2eClusterConfig(),
-		cluster.WithName("e2e-kubectl"),
-		cluster.WithIngressPort(30087),
 	)
 	if err != nil {
 		t.Errorf("failed to create cluster: %v", err)

--- a/e2e/kubernetes/kubernetes_e2e_test.go
+++ b/e2e/kubernetes/kubernetes_e2e_test.go
@@ -21,10 +21,10 @@ import (
 )
 
 func Test_Kubernetes(t *testing.T) {
+	t.Parallel()
+
 	cluster, err := cluster.BuildE2eCluster(
 		cluster.DefaultE2eClusterConfig(),
-		cluster.WithName("e2e-kubernetes"),
-		cluster.WithIngressPort(30081),
 	)
 	if err != nil {
 		t.Errorf("failed to create cluster: %v", err)

--- a/pkg/testutils/e2e/cluster/cluster.go
+++ b/pkg/testutils/e2e/cluster/cluster.go
@@ -323,11 +323,6 @@ func BuildE2eCluster(
 	return createE2eCluster(e2eConfig)
 }
 
-// BuildDefaultE2eCluster builds an e2e test cluster with the default configuration
-func BuildDefaultE2eCluster() (E2eCluster, error) {
-	return BuildE2eCluster(DefaultE2eClusterConfig())
-}
-
 // DeleteE2eCluster deletes an existing e2e cluster
 func DeleteE2eCluster(name string, quiet bool) error {
 	return cluster.DeleteCluster(name, quiet)


### PR DESCRIPTION
# Description

In order to facilitate reusing the test cluster use default options in all e2e tests.

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [X] I have run linter locally (`make lint`) and all checks pass.
- [X] I have run tests locally (`make test`) and all tests pass.
- [X] I have run relevant e2e test locally (`make e2e-xxx` for `agent`, `disruptors`, `kubernetes` or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
