### PR TITLE
e2e/agent: fix use of whole pod object as string in Fatalf message

### DIFF
--- a/e2e/agent/agent_e2e_test.go
+++ b/e2e/agent/agent_e2e_test.go
@@ -281,7 +281,7 @@ func Test_Agent(t *testing.T) {
 
 					port, err := kc.ForwardPodPort(ctx, namespace, tc.pod.Name, uint(tc.port))
 					if err != nil {
-						t.Fatalf("forwarding port from %s/%s: %v", namespace, tc.pod, err)
+						t.Fatalf("forwarding port from %s/%s: %v", namespace, tc.pod.Name, err)
 					}
 
 					err = tc.check.Verify(k8s, net.JoinHostPort("localhost", fmt.Sprint(port)), namespace)


### PR DESCRIPTION
# Description

Fixes a bug where a whole pod object cannot be used as a string.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make test`) and all tests pass.
- [x] I have run relevant e2e test locally (`make e2e-xxx` for `agent`, `disruptors`, `kubernetes` or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
