### PR TITLE
Modify http and grpc proxy to receive a listener rather than creating it

### DIFF
--- a/cmd/agent/commands/grpc.go
+++ b/cmd/agent/commands/grpc.go
@@ -42,15 +42,22 @@ func BuildGrpcCmd(env runtime.Environment, config *agent.Config) *cobra.Command 
 				return fmt.Errorf("upstream host cannot be localhost when running in transparent mode")
 			}
 
+			agent, err := agent.Start(env, config)
+			if err != nil {
+				return fmt.Errorf("initializing agent: %w", err)
+			}
+
+			defer agent.Stop()
+
 			listenAddress := net.JoinHostPort("", fmt.Sprint(port))
 			upstreamAddress := net.JoinHostPort(upstreamHost, fmt.Sprint(targetPort))
 
-			proxyConfig := grpc.ProxyConfig{
-				ListenAddress:   listenAddress,
-				UpstreamAddress: upstreamAddress,
+			listener, err := net.Listen("tcp", listenAddress)
+			if err != nil {
+				return fmt.Errorf("setting up listener at %q: %w", listenAddress, err)
 			}
 
-			proxy, err := grpc.NewProxy(proxyConfig, disruption)
+			proxy, err := grpc.NewProxy(listener, upstreamAddress, disruption)
 			if err != nil {
 				return err
 			}
@@ -79,8 +86,6 @@ func BuildGrpcCmd(env runtime.Environment, config *agent.Config) *cobra.Command 
 			if err != nil {
 				return err
 			}
-
-			agent := agent.BuildAgent(env, config)
 
 			return agent.ApplyDisruption(cmd.Context(), disruptor, duration)
 		},

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -4,6 +4,8 @@ package agent
 import (
 	"context"
 	"fmt"
+	"io"
+	"os"
 	"syscall"
 	"time"
 
@@ -19,48 +21,51 @@ type Config struct {
 
 // Agent maintains the state required for executing an agent command
 type Agent struct {
-	env    runtime.Environment
-	config *Config
+	env           runtime.Environment
+	sc            <-chan os.Signal
+	profileCloser io.Closer
 }
 
-// BuildAgent builds a instance of an agent
-func BuildAgent(env runtime.Environment, config *Config) *Agent {
-	return &Agent{
-		env:    env,
-		config: config,
+// Start creates and starts a new instance of an agent.
+// Returned agent is guaranteed to be unique in the environment it is running, and will handle signals sent to the
+// process.
+// Callers must Stop the returned agent at the end of its lifecycle.
+func Start(env runtime.Environment, config *Config) (*Agent, error) {
+	a := &Agent{
+		env: env,
 	}
+
+	if err := a.start(config); err != nil {
+		a.Stop() // Stop any initialized component if initialization failed.
+		return nil, err
+	}
+
+	return a, nil
 }
 
-// ApplyDisruption applies a disruption to the target
-func (r *Agent) ApplyDisruption(ctx context.Context, disruptor protocol.Disruptor, duration time.Duration) error {
-	sc := r.env.Signal().Notify(syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
-	defer func() {
-		r.env.Signal().Reset()
-	}()
+func (a *Agent) start(config *Config) error {
+	a.sc = a.env.Signal().Notify(syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 
-	acquired, err := r.env.Lock().Acquire()
+	acquired, err := a.env.Lock().Acquire()
 	if err != nil {
 		return fmt.Errorf("could not acquire process lock: %w", err)
 	}
+
 	if !acquired {
 		return fmt.Errorf("another instance of the agent is already running")
 	}
 
-	defer func() {
-		_ = r.env.Lock().Release()
-	}()
-
 	// start profiler
-	profiler, err := r.env.Profiler().Start(ctx, *r.config.Profiler)
+	a.profileCloser, err = a.env.Profiler().Start(*config.Profiler)
 	if err != nil {
 		return fmt.Errorf("could not create profiler %w", err)
 	}
 
-	// ensure the profiler is closed even if there's an error executing the command
-	defer func() {
-		_ = profiler.Close()
-	}()
+	return nil
+}
 
+// ApplyDisruption applies a disruption to the target
+func (a *Agent) ApplyDisruption(ctx context.Context, disruptor protocol.Disruptor, duration time.Duration) error {
 	// set context for command
 	ctx, cancel := context.WithCancel(ctx)
 
@@ -83,7 +88,17 @@ func (r *Agent) ApplyDisruption(ctx context.Context, disruptor protocol.Disrupto
 		return ctx.Err()
 	case err := <-cc:
 		return err
-	case s := <-sc:
+	case s := <-a.sc:
 		return fmt.Errorf("received signal %q", s)
+	}
+}
+
+// Stop stops a running agent: It releases
+func (a *Agent) Stop() {
+	a.env.Signal().Reset()
+	_ = a.env.Lock().Release()
+
+	if a.profileCloser != nil {
+		_ = a.profileCloser.Close()
 	}
 }

--- a/pkg/agent/agent_test.go
+++ b/pkg/agent/agent_test.go
@@ -63,7 +63,12 @@ func Test_CancelContext(t *testing.T) {
 			t.Parallel()
 			env := runtime.NewFakeRuntime(tc.args, tc.vars)
 
-			agent := BuildAgent(env, tc.config)
+			agent, err := Start(env, tc.config)
+			if err != nil {
+				t.Fatalf("starting agent: %v", err)
+			}
+
+			defer agent.Stop()
 
 			ctx, cancel := context.WithCancel(context.Background())
 			go func() {
@@ -72,7 +77,7 @@ func Test_CancelContext(t *testing.T) {
 			}()
 
 			disruptor := &FakeProtocolDisruptor{}
-			err := agent.ApplyDisruption(ctx, disruptor, tc.delay)
+			err = agent.ApplyDisruption(ctx, disruptor, tc.delay)
 			if !errors.Is(err, tc.expected) {
 				t.Errorf("expected %v got %v", tc.err, err)
 			}
@@ -126,7 +131,12 @@ func Test_Signals(t *testing.T) {
 			t.Parallel()
 			env := runtime.NewFakeRuntime(tc.args, tc.vars)
 
-			agent := BuildAgent(env, tc.config)
+			agent, err := Start(env, tc.config)
+			if err != nil {
+				t.Fatalf("starting agent: %v", err)
+			}
+
+			defer agent.Stop()
 
 			go func() {
 				time.Sleep(1 * time.Second)
@@ -136,7 +146,7 @@ func Test_Signals(t *testing.T) {
 			}()
 
 			disruptor := &FakeProtocolDisruptor{}
-			err := agent.ApplyDisruption(context.TODO(), disruptor, tc.delay)
+			err = agent.ApplyDisruption(context.TODO(), disruptor, tc.delay)
 			if tc.expectErr && err == nil {
 				t.Errorf("should had failed")
 				return

--- a/pkg/runtime/fake.go
+++ b/pkg/runtime/fake.go
@@ -1,7 +1,6 @@
 package runtime
 
 import (
-	"context"
 	"io"
 	"os"
 	"strings"
@@ -110,7 +109,7 @@ func NewFakeProfiler() *FakeProfiler {
 }
 
 // Start updates the FakeProfiler to registers it was started
-func (p *FakeProfiler) Start(context.Context, profiler.Config) (io.Closer, error) {
+func (p *FakeProfiler) Start(profiler.Config) (io.Closer, error) {
 	p.started = true
 	return p, nil
 }

--- a/pkg/runtime/profiler/profiler.go
+++ b/pkg/runtime/profiler/profiler.go
@@ -3,7 +3,6 @@
 package profiler
 
 import (
-	"context"
 	"io"
 )
 
@@ -18,7 +17,7 @@ type Config struct {
 // Profiler defines the methods to control execution profiling
 type Profiler interface {
 	// Start stars the collection of profiling information with the given configuration
-	Start(ctx context.Context, config Config) (io.Closer, error)
+	Start(config Config) (io.Closer, error)
 }
 
 // Probe defines the interface for controlling a profiling probe
@@ -37,7 +36,7 @@ func NewProfiler() Profiler {
 }
 
 // Start stars the collection of profiling information with the given configuration
-func (p *profiler) Start(_ context.Context, config Config) (io.Closer, error) {
+func (p *profiler) Start(config Config) (io.Closer, error) {
 	probes, err := buildProbes(config)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Description

This PR changes HTTP an GRPC proxy constructors to receive a listener as an argument, instead of receiving an address and creating it themselves as they used to.

Unblocks: https://github.com/grafana/xk6-disruptor/issues/314

Doing this allows to move most of the startup logic to the constructor. Doing so, removes the potential race condition between `Start` and `Stop`.
Fixes: https://github.com/grafana/xk6-disruptor/issues/319


Fixes # (issue)

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make test`) and all tests pass.
- [x] I have run relevant e2e test locally (`make e2e-xxx` for `agent`, `disruptors`, `kubernetes` or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
