### PR TITLE
Prevent race condition waiting for condition

### DIFF
--- a/pkg/kubernetes/helpers/pods_test.go
+++ b/pkg/kubernetes/helpers/pods_test.go
@@ -117,14 +117,12 @@ func TestPods_Wait(t *testing.T) {
 }
 
 func TestPods_AddEphemeralContainer(t *testing.T) {
-	t.Skip("Skipping due to flaky behavior. See issue #280")
 	t.Parallel()
 
 	type TestCase struct {
 		test        string
 		podName     string
 		expectError bool
-		container   string
 		status      corev1.ContainerStatus
 		options     AttachOptions
 	}
@@ -135,7 +133,6 @@ func TestPods_AddEphemeralContainer(t *testing.T) {
 			test:        "Create ephemeral container not waiting",
 			podName:     "test-pod",
 			expectError: false,
-			container:   "ephemeral",
 			status: corev1.ContainerStatus{
 				Name: "ephemeral",
 				State: corev1.ContainerState{
@@ -196,6 +193,7 @@ func TestPods_AddEphemeralContainer(t *testing.T) {
 				pod.Status.EphemeralContainerStatuses = []corev1.ContainerStatus{
 					tc.status,
 				}
+
 				// update pod and stop watching updates
 				return pod, false, nil
 			}
@@ -221,7 +219,7 @@ func TestPods_AddEphemeralContainer(t *testing.T) {
 				tc.options,
 			)
 			if !tc.expectError && err != nil {
-				t.Errorf("unexpected error: %v", err)
+				t.Errorf("failed: %v", err)
 				return
 			}
 		})


### PR DESCRIPTION
# Description

Apply a get-then-watch strategy when waiting for conditions in a Pod, to avoid situations when the watch misses the change that made the condition true. 

Fixes #280 

# Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works.   
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make test`) and all tests pass.
- [x] I have run relevant e2e test locally (`make e2e-xxx` for `agent`, `disruptors`, `kubernetes` or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
