### PR TITLE
Implement kubectl helper integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,11 @@ integration-agent: agent-image
 integration-kubernetes:
 	go test -tags integration ./pkg/kubernetes/...
 
-integration: integration-agent integration-kubernetes
+integration-kubectl:
+	go test -tags integration ./pkg/testutils/e2e/kubectl/
+
+integration: integration-agent integration-kubernetes integration-kubectl
+
 
 # Running with -buildvcs=false works around the issue of `go list all` failing when git, which runs as root inside
 # the container, refuses to operate on the disruptor source tree as it is not owned by the same user (root).

--- a/pkg/kubernetes/integration_test.go
+++ b/pkg/kubernetes/integration_test.go
@@ -73,7 +73,7 @@ func Test_Kubernetes(t *testing.T) {
 		t.Fatalf("failed to create rest client for kubernetes : %s", err)
 	}
 
-	k8s, err := newFromConfig(restcfg)
+	k8s, err := NewFromConfig(restcfg)
 	if err != nil {
 		t.Fatalf("error creating kubernetes client: %v", err)
 	}
@@ -299,7 +299,7 @@ func Test_UnsupportedKubernetesVersion(t *testing.T) {
 		t.Fatalf("failed to create rest client for kubernetes : %s", err)
 	}
 
-	_, err = newFromConfig(restcfg)
+	_, err = NewFromConfig(restcfg)
 	if err == nil {
 		t.Errorf("should had failed creating kubernetes client")
 		return

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -31,8 +31,8 @@ type k8s struct {
 	kubernetes.Interface
 }
 
-// newFromConfig returns a Kubernetes instance configured with the provided kubeconfig.
-func newFromConfig(config *rest.Config) (Kubernetes, error) {
+// NewFromConfig returns a Kubernetes instance configured with the provided kubeconfig.
+func NewFromConfig(config *rest.Config) (Kubernetes, error) {
 	// As per the discussion in [1] client side rate limiting is no longer required.
 	// Setting a large limit
 	// [1] https://github.com/kubernetes/kubernetes/issues/111880
@@ -62,7 +62,7 @@ func NewFromKubeconfig(kubeconfig string) (Kubernetes, error) {
 		return nil, err
 	}
 
-	return newFromConfig(config)
+	return NewFromConfig(config)
 }
 
 // New returns a Kubernetes instance or an error when no config is eligible to be used.
@@ -73,7 +73,7 @@ func NewFromKubeconfig(kubeconfig string) (Kubernetes, error) {
 func New() (Kubernetes, error) {
 	k8sConfig, err := rest.InClusterConfig()
 	if err == nil {
-		return newFromConfig(k8sConfig)
+		return NewFromConfig(k8sConfig)
 	}
 
 	if !errors.Is(err, rest.ErrNotInCluster) {

--- a/pkg/testutils/k3sutils/k3sutils.go
+++ b/pkg/testutils/k3sutils/k3sutils.go
@@ -1,0 +1,57 @@
+// Package k3sutils implements helper functions for tests using TestContainer's k3s module
+package k3sutils
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/testcontainers/testcontainers-go"
+)
+
+// regexMatcher process lines from logs and notifies when a match is found
+type regexMatcher struct {
+	exp   *regexp.Regexp
+	found chan (bool)
+}
+
+// Accept implements the LogConsumer interface
+func (a *regexMatcher) Accept(log testcontainers.Log) {
+	if a.exp.MatchString(string(log.Content)) {
+		a.found <- true
+	}
+}
+
+// WaitForRegex waits until a match for the given regex is found in the log produced by the container
+// This utility function is a workaround for https://github.com/testcontainers/testcontainers-go/issues/1541
+func WaitForRegex(ctx context.Context, container testcontainers.Container, exp string, timeout time.Duration) error {
+	regexp, err := regexp.Compile(exp)
+	if err != nil {
+		return err
+	}
+
+	found := make(chan bool)
+	container.FollowOutput(&regexMatcher{
+		exp:   regexp,
+		found: found,
+	})
+
+	err = container.StartLogProducer(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = container.StopLogProducer()
+	}()
+
+	expired := time.After(timeout)
+	select {
+	case <-found:
+		return nil
+	case <-expired:
+		return fmt.Errorf("timeout waiting for a match")
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}


### PR DESCRIPTION
# Description

Reimplements `kubectl` package e2e tests using TestContainers and move them to the package as integration tests

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works.   
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make test`) and all tests pass.
- [x] I have run relevant integration test locally (`make integration-xxx` for affected packages)
- [x] I have run e2e test locally
- [ ] Any dependent changes have been merged and published in downstream modules<br>
      
 
