### PR TITLE
e2e: preload httpbin and grpcbin images

### DIFF
--- a/e2e/disruptors/pod_e2e_test.go
+++ b/e2e/disruptors/pod_e2e_test.go
@@ -39,6 +39,14 @@ func Test_PodDisruptor(t *testing.T) {
 		_ = cluster.Cleanup()
 	})
 
+	err = cluster.Load(
+		fixtures.BuildHttpbinPod().Spec.Containers[0].Image,
+		fixtures.BuildGrpcpbinPod().Spec.Containers[0].Image,
+	)
+	if err != nil {
+		t.Fatalf("preloading test pod images: %v", err)
+	}
+
 	k8s, err := kubernetes.NewFromKubeconfig(cluster.Kubeconfig())
 	if err != nil {
 		t.Errorf("error creating kubernetes client: %v", err)

--- a/e2e/disruptors/service_e2e_test.go
+++ b/e2e/disruptors/service_e2e_test.go
@@ -34,6 +34,13 @@ func Test_ServiceDisruptor(t *testing.T) {
 		_ = cluster.Cleanup()
 	})
 
+	err = cluster.Load(
+		fixtures.BuildHttpbinPod().Spec.Containers[0].Image,
+	)
+	if err != nil {
+		t.Fatalf("preloading test pod images: %v", err)
+	}
+
 	k8s, err := kubernetes.NewFromKubeconfig(cluster.Kubeconfig())
 	if err != nil {
 		t.Errorf("error creating kubernetes client: %v", err)

--- a/pkg/testutils/e2e/cluster/cluster.go
+++ b/pkg/testutils/e2e/cluster/cluster.go
@@ -45,6 +45,8 @@ type E2eCluster interface {
 	Kubeconfig() string
 	// Name returns the name of the cluster
 	Name() string
+	// Load loads the supplied images to the clusters' nodes.
+	Load(images ...string) error
 }
 
 const contourConfig = `
@@ -108,12 +110,8 @@ func InstallContourIngress(ctx context.Context, cluster E2eCluster) error {
 // TODO: allow override of default port using an environment variable (E2E_INGRESS_PORT)
 func DefaultE2eClusterConfig() E2eClusterConfig {
 	return E2eClusterConfig{
-		Name: "e2e-test",
-		Images: []string{
-			"ghcr.io/grafana/xk6-disruptor-agent:latest",
-			"kennethreitz/httpbin",
-			"moul/grpcbin",
-		},
+		Name:        "e2e-test",
+		Images:      []string{"ghcr.io/grafana/xk6-disruptor-agent:latest"},
 		IngressAddr: "localhost",
 		IngressPort: 30080,
 		Reuse:       false,
@@ -354,4 +352,8 @@ func (c *e2eCluster) Ingress() string {
 
 func (c *e2eCluster) Kubeconfig() string {
 	return c.cluster.Kubeconfig()
+}
+
+func (c *e2eCluster) Load(images ...string) error {
+	return c.cluster.Load(images...)
 }

--- a/pkg/testutils/e2e/cluster/cluster.go
+++ b/pkg/testutils/e2e/cluster/cluster.go
@@ -108,8 +108,12 @@ func InstallContourIngress(ctx context.Context, cluster E2eCluster) error {
 // TODO: allow override of default port using an environment variable (E2E_INGRESS_PORT)
 func DefaultE2eClusterConfig() E2eClusterConfig {
 	return E2eClusterConfig{
-		Name:        "e2e-test",
-		Images:      []string{"ghcr.io/grafana/xk6-disruptor-agent:latest"},
+		Name: "e2e-test",
+		Images: []string{
+			"ghcr.io/grafana/xk6-disruptor-agent:latest",
+			"kennethreitz/httpbin",
+			"moul/grpcbin",
+		},
 		IngressAddr: "localhost",
 		IngressPort: 30080,
 		Reuse:       false,


### PR DESCRIPTION
# Description

This PR adds the `kennethreitz/httpbin` and `moul/grpcbin` to the e2e cluster before tests are run. By doing this, images will be ready when e2e scenarios run, so the time that they take to download won't count against the test timeout, reducing test flakyness.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make test`) and all tests pass.
- [ ] I have run relevant integration test locally (`make integration-xxx` for affected packages)
- [x] I have run relevant e2e test locally (`make e2e-xxx` for `disruptors`, or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
