### PR TITLE
cmd: replace SetContext + Execute with ExecuteContext

### DIFF
--- a/cmd/agent/commands/root.go
+++ b/cmd/agent/commands/root.go
@@ -38,9 +38,8 @@ func NewRootCommand(env runtime.Environment) *RootCommand {
 func (c *RootCommand) Execute(ctx context.Context) error {
 	rootArgs := c.env.Args()[1:]
 	c.cmd.SetArgs(rootArgs)
-	c.cmd.SetContext(ctx)
 
-	return c.cmd.Execute()
+	return c.cmd.ExecuteContext(ctx)
 }
 
 func buildRootCmd(c *agent.Config) *cobra.Command {


### PR DESCRIPTION
# Description

This PR removes the only usage of `SetContext` in `cobra.Command` instances. This will unblock downgrading cobra to 1.4.x, which is the same version k6 is using upstream.

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [x] I have run linter locally (`make lint`) and all checks pass.
- [x] I have run tests locally (`make test`) and all tests pass.
- [x] I have run relevant integration test locally (`make integration-xxx` for affected packages)
- [x] I have run relevant e2e test locally (`make e2e-xxx` for `disruptors`, or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
