### PR TITLE
ci/sync-core-deps: use go 1.21, small improvements

### DIFF
--- a/.github/workflows/sync-core-deps.yaml
+++ b/.github/workflows/sync-core-deps.yaml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
+        with:
+          go-version: "1.21"
       - name: Sync dependencies
         run: |
           git checkout -b "$BRANCH_NAME"


### PR DESCRIPTION
# Description

Go 1.21 is the only version where this script works as intended ([1.19](https://github.com/roobre/xk6-disruptor/pull/30/commits/2405f0d2915180657a224d611b33b88b79f70d59) and [1.20](https://github.com/grafana/xk6-disruptor/pull/347/commits/42c0fb8fd79f8dd98bbc004468ebd17b7ed8fc85) will re-add the conflicting grpc dependency, as it can be observed in the linked commits.)

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make test`) and all tests pass.
- [ ] I have run relevant integration test locally (`make integration-xxx` for affected packages)
- [ ] I have run relevant e2e test locally (`make e2e-xxx` for `disruptors`, or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
