### PR TITLE
hack/depsync: add nolint directive on hard to preallocate slice

### DIFF
--- a/hack/depsync/depsync.go
+++ b/hack/depsync/depsync.go
@@ -54,6 +54,7 @@ func main() {
 		log.Fatalf("reading k6 core dependencies: %v", err)
 	}
 
+	//nolint:prealloc // Number of mismatched deps cannot be accurately predicted.
 	var mismatched []string
 	for dep, version := range ownDeps {
 		coreVersion, inCore := coreDeps[dep]


### PR DESCRIPTION
# Description

Single line PR fixing a linter warning that I somehow missed on #349 

# Checklist:

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [x] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make test`) and all tests pass.
- [ ] I have run relevant integration test locally (`make integration-xxx` for affected packages)
- [ ] I have run relevant e2e test locally (`make e2e-xxx` for `disruptors`, or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
