### PR TITLE
Replace hub in ci workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -220,7 +220,7 @@ jobs:
           MESSAGE="$(cat ./releases/${VERSION}.md)"
           assets=()
           for asset in ./dist/*; do
-            assets+=("-a" "$asset")
+            assets+=("$asset")
           done
-          hub release create "${assets[@]}" -m "$VERSION" -m "$MESSAGE" "$VERSION"
-          
+          gh release create "$VERSION" --target "$VERSION" -F "./releases/${VERSION}.md" "${assets[@]}"
+


### PR DESCRIPTION
# Description

GitHub [removed hub in from ci runners](https://github.com/actions/runner-images/issues/8362). This PR replaces `hub` by `gh` cli.