### PR TITLE
Unify fault injection commands

### DIFF
--- a/e2e/disruptors/pod_e2e_test.go
+++ b/e2e/disruptors/pod_e2e_test.go
@@ -12,8 +12,10 @@ import (
 	"time"
 
 	"github.com/grafana/xk6-disruptor/pkg/agent/protocol"
+	"github.com/grafana/xk6-disruptor/pkg/types/intstr"
+
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
+	k8sintstr "k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/grafana/xk6-disruptor/pkg/disruptors"
 	"github.com/grafana/xk6-disruptor/pkg/kubernetes"
@@ -71,7 +73,7 @@ func Test_PodDisruptor(t *testing.T) {
 				port:    80,
 				injector: func(d disruptors.PodDisruptor) error {
 					fault := disruptors.HTTPFault{
-						Port:      80,
+						Port:      intstr.FromInt(80),
 						ErrorRate: 1.0,
 						ErrorCode: 500,
 					}
@@ -97,7 +99,7 @@ func Test_PodDisruptor(t *testing.T) {
 				port:    9000,
 				injector: func(d disruptors.PodDisruptor) error {
 					fault := disruptors.GrpcFault{
-						Port:       9000,
+						Port:       intstr.FromInt(9000),
 						ErrorRate:  1.0,
 						StatusCode: 14,
 						Exclude:    "grpc.reflection.v1alpha.ServerReflection,grpc.reflection.v1.ServerReflection",
@@ -135,7 +137,7 @@ func Test_PodDisruptor(t *testing.T) {
 					namespace,
 					tc.pod,
 					tc.service,
-					intstr.FromInt(tc.port),
+					k8sintstr.FromInt(tc.port),
 					30*time.Second,
 				)
 				if err != nil {
@@ -225,7 +227,7 @@ func Test_PodDisruptor(t *testing.T) {
 			namespace,
 			fixtures.BuildHttpbinPod(),
 			service,
-			intstr.FromInt(80),
+			k8sintstr.FromInt(80),
 			30*time.Second,
 		)
 		if err != nil {
@@ -251,7 +253,7 @@ func Test_PodDisruptor(t *testing.T) {
 		}
 
 		fault := disruptors.HTTPFault{
-			Port:      80,
+			Port:      intstr.FromInt(80),
 			ErrorRate: 1.0,
 			ErrorCode: 500,
 		}

--- a/e2e/disruptors/service_e2e_test.go
+++ b/e2e/disruptors/service_e2e_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
+	k8sintstr "k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/grafana/xk6-disruptor/pkg/disruptors"
 	"github.com/grafana/xk6-disruptor/pkg/kubernetes"
@@ -18,6 +18,8 @@ import (
 	"github.com/grafana/xk6-disruptor/pkg/testutils/e2e/deploy"
 	"github.com/grafana/xk6-disruptor/pkg/testutils/e2e/fixtures"
 	"github.com/grafana/xk6-disruptor/pkg/testutils/e2e/kubernetes/namespace"
+	"github.com/grafana/xk6-disruptor/pkg/types/intstr"
+
 )
 
 func Test_ServiceDisruptor(t *testing.T) {
@@ -65,7 +67,7 @@ func Test_ServiceDisruptor(t *testing.T) {
 				port:    80,
 				injector: func(d disruptors.ServiceDisruptor) error {
 					fault := disruptors.HTTPFault{
-						Port:      80,
+						Port:      intstr.FromInt(80),
 						ErrorRate: 1.0,
 						ErrorCode: 500,
 					}
@@ -100,7 +102,7 @@ func Test_ServiceDisruptor(t *testing.T) {
 					namespace,
 					tc.pod,
 					tc.service,
-					intstr.FromInt(tc.port),
+					k8sintstr.FromInt(tc.port),
 					30*time.Second,
 				)
 				if err != nil {

--- a/pkg/api/convert_test.go
+++ b/pkg/api/convert_test.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/grafana/xk6-disruptor/pkg/types/intstr"
 )
 
 func Test_Conversions(t *testing.T) {
@@ -13,13 +15,15 @@ func Test_Conversions(t *testing.T) {
 		SubfieldString string
 	}
 	type TypedFields struct {
-		FieldString   string
-		FieldDuration time.Duration
-		FieldInt      int64
-		FieldFloat    float64
-		FieldStruct   StructField
-		FieldMap      map[string]string
-		FieldArray    []string
+		IntOrStrStr intstr.IntOrString
+		IntOrStrInt intstr.IntOrString
+		String      string
+		Duration    time.Duration
+		Int         int64
+		Float       float64
+		Struct      StructField
+		Map         map[string]string
+		Array       []string
 	}
 
 	testCases := []struct {
@@ -41,6 +45,27 @@ func Test_Conversions(t *testing.T) {
 			value:       int64(1),
 			target:      new(int64),
 			expected:    int64(1),
+			expectError: false,
+		},
+		{
+			description: "IntOrString int conversion",
+			value:       int64(1),
+			target:      new(intstr.IntOrString),
+			expected:    intstr.FromInt32(1),
+			expectError: false,
+		},
+		{
+			description: "IntOrString string to int conversion",
+			value:       "1",
+			target:      new(intstr.IntOrString),
+			expected:    intstr.FromInt32(1),
+			expectError: false,
+		},
+		{
+			description: "IntOrString string conversion",
+			value:       "one",
+			target:      new(intstr.IntOrString),
+			expected:    intstr.FromString("one"),
 			expectError: false,
 		},
 		{
@@ -153,31 +178,35 @@ func Test_Conversions(t *testing.T) {
 		{
 			description: "Struct field conversion",
 			value: map[string]interface{}{
-				"fieldString":   "string",
-				"fieldInt":      int64(1),
-				"fieldDuration": "1s",
-				"fieldFloat":    float64(1.0),
-				"fieldStruct": map[string]interface{}{
+				"intOrStrStr": "uno",
+				"intOrStrInt": int64(1),
+				"string":      "string",
+				"int":         int64(1),
+				"duration":    "1s",
+				"float":       float64(1.0),
+				"struct": map[string]interface{}{
 					"subfieldInt":    int64(0),
 					"subfieldString": "string",
 				},
-				"fieldMap": map[string]interface{}{
+				"map": map[string]interface{}{
 					"key": "value",
 				},
-				"fieldArray": []interface{}{"string"},
+				"array": []interface{}{"string"},
 			},
 			target: &TypedFields{},
 			expected: TypedFields{
-				FieldString:   "string",
-				FieldInt:      1,
-				FieldDuration: time.Second,
-				FieldFloat:    1.0,
-				FieldStruct: StructField{
+				IntOrStrStr: intstr.FromString("uno"),
+				IntOrStrInt: intstr.FromInt32(1),
+				String:      "string",
+				Int:         1,
+				Duration:    time.Second,
+				Float:       1.0,
+				Struct: StructField{
 					SubfieldInt:    0,
 					SubfieldString: "string",
 				},
-				FieldArray: []string{"string"},
-				FieldMap: map[string]string{
+				Array: []string{"string"},
+				Map: map[string]string{
 					"key": "value",
 				},
 			},

--- a/pkg/disruptors/commads.go
+++ b/pkg/disruptors/commads.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/grafana/xk6-disruptor/pkg/types/intstr"
 	"github.com/grafana/xk6-disruptor/pkg/utils"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -22,7 +24,7 @@ func buildGrpcFaultCmd(
 	}
 
 	// TODO: make port mandatory
-	if fault.Port != 0 {
+	if fault.Port != intstr.NullValue {
 		cmd = append(cmd, "-t", fmt.Sprint(fault.Port))
 	}
 
@@ -75,7 +77,7 @@ func buildHTTPFaultCmd(
 	}
 
 	// TODO: make port mandatory
-	if fault.Port != 0 {
+	if fault.Port != intstr.NullValue {
 		cmd = append(cmd, "-t", fmt.Sprint(fault.Port))
 	}
 
@@ -130,7 +132,7 @@ type PodHTTPFaultCommand struct {
 // Commands return the command for injecting a HttpFault in a Pod
 func (c PodHTTPFaultCommand) Commands(pod corev1.Pod) (VisitCommands, error) {
 	if !utils.HasPort(pod, c.fault.Port) {
-		return VisitCommands{}, fmt.Errorf("pod %q does not expose port %d", pod.Name, c.fault.Port)
+		return VisitCommands{}, fmt.Errorf("pod %q does not expose port %q", pod.Name, c.fault.Port.Str())
 	}
 
 	if utils.HasHostNetwork(pod) {
@@ -158,7 +160,7 @@ type PodGrpcFaultCommand struct {
 // Commands return the command for injecting a GrpcFault in a Pod
 func (c PodGrpcFaultCommand) Commands(pod corev1.Pod) (VisitCommands, error) {
 	if !utils.HasPort(pod, c.fault.Port) {
-		return VisitCommands{}, fmt.Errorf("pod %q does not expose port %d", pod.Name, c.fault.Port)
+		return VisitCommands{}, fmt.Errorf("pod %q does not expose port %q", pod.Name, c.fault.Port.Str())
 	}
 
 	targetAddress, err := utils.PodIP(pod)

--- a/pkg/disruptors/commads_test.go
+++ b/pkg/disruptors/commads_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/grafana/xk6-disruptor/pkg/testutils/command"
 	"github.com/grafana/xk6-disruptor/pkg/testutils/kubernetes/builders"
+	"github.com/grafana/xk6-disruptor/pkg/types/intstr"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -44,7 +45,7 @@ func Test_PodHTTPFaultCommandGenerator(t *testing.T) {
 			fault: HTTPFault{
 				ErrorRate: 0.1,
 				ErrorCode: 500,
-				Port:      80,
+				Port:      intstr.FromInt(80),
 			},
 			opts:        HTTPDisruptionOptions{},
 			duration:    60 * time.Second,
@@ -64,7 +65,7 @@ func Test_PodHTTPFaultCommandGenerator(t *testing.T) {
 				ErrorRate: 0.1,
 				ErrorCode: 500,
 				ErrorBody: "{\"error\": 500}",
-				Port:      80,
+				Port:      intstr.FromInt(80),
 			},
 			opts:     HTTPDisruptionOptions{},
 			duration: 60 * time.Second,
@@ -77,7 +78,7 @@ func Test_PodHTTPFaultCommandGenerator(t *testing.T) {
 			cmdError:    nil,
 			fault: HTTPFault{
 				AverageDelay: 100 * time.Millisecond,
-				Port:         80,
+				Port:         intstr.FromInt(80),
 			},
 			opts:     HTTPDisruptionOptions{},
 			duration: 60 * time.Second,
@@ -90,7 +91,7 @@ func Test_PodHTTPFaultCommandGenerator(t *testing.T) {
 			cmdError:    nil,
 			fault: HTTPFault{
 				Exclude: "/path1,/path2",
-				Port:    80,
+				Port:    intstr.FromInt(80),
 			},
 			opts:     HTTPDisruptionOptions{},
 			duration: 60 * time.Second,
@@ -101,7 +102,7 @@ func Test_PodHTTPFaultCommandGenerator(t *testing.T) {
 			expectedCmd: "",
 			expectError: true,
 			fault: HTTPFault{
-				Port: 8080,
+				Port: intstr.FromInt(8080),
 			},
 			opts:     HTTPDisruptionOptions{},
 			duration: 60,
@@ -120,7 +121,7 @@ func Test_PodHTTPFaultCommandGenerator(t *testing.T) {
 			expectedCmd: "",
 			expectError: true,
 			fault: HTTPFault{
-				Port: 80,
+				Port: intstr.FromInt(80),
 			},
 			opts:     HTTPDisruptionOptions{},
 			duration: 60,
@@ -141,7 +142,7 @@ func Test_PodHTTPFaultCommandGenerator(t *testing.T) {
 			expectedCmd: "",
 			expectError: true,
 			fault: HTTPFault{
-				Port: 80,
+				Port: intstr.FromInt(80),
 			},
 			opts:     HTTPDisruptionOptions{},
 			duration: 60,
@@ -196,7 +197,7 @@ func Test_PodGrpcPFaultCommandGenerator(t *testing.T) {
 			fault: GrpcFault{
 				ErrorRate:  0.1,
 				StatusCode: 14,
-				Port:       3000,
+				Port:       intstr.FromInt(3000),
 			},
 			opts:        GrpcDisruptionOptions{},
 			duration:    60 * time.Second,
@@ -211,7 +212,7 @@ func Test_PodGrpcPFaultCommandGenerator(t *testing.T) {
 				ErrorRate:     0.1,
 				StatusCode:    14,
 				StatusMessage: "internal error",
-				Port:          3000,
+				Port:          intstr.FromInt(3000),
 			},
 			opts:        GrpcDisruptionOptions{},
 			duration:    60 * time.Second,
@@ -224,7 +225,7 @@ func Test_PodGrpcPFaultCommandGenerator(t *testing.T) {
 			target: buildPodWithPort("my-app-pod", "grpc", 3000),
 			fault: GrpcFault{
 				AverageDelay: 100 * time.Millisecond,
-				Port:         3000,
+				Port:         intstr.FromInt(3000),
 			},
 			opts:        GrpcDisruptionOptions{},
 			duration:    60 * time.Second,
@@ -237,7 +238,7 @@ func Test_PodGrpcPFaultCommandGenerator(t *testing.T) {
 			target: buildPodWithPort("my-app-pod", "grpc", 3000),
 			fault: GrpcFault{
 				Exclude: "service1,service2",
-				Port:    3000,
+				Port:    intstr.FromInt(3000),
 			},
 			opts:        GrpcDisruptionOptions{},
 			duration:    60 * time.Second,
@@ -249,7 +250,7 @@ func Test_PodGrpcPFaultCommandGenerator(t *testing.T) {
 			title:       "Container port not found",
 			target:      buildPodWithPort("my-app-pod", "grpc", 3000),
 			expectError: true,
-			fault:       GrpcFault{Port: 8080},
+			fault:       GrpcFault{Port: intstr.FromInt(8080)},
 			opts:        GrpcDisruptionOptions{},
 			duration:    60,
 		},

--- a/pkg/disruptors/pod.go
+++ b/pkg/disruptors/pod.go
@@ -11,16 +11,17 @@ import (
 
 	"github.com/grafana/xk6-disruptor/pkg/kubernetes"
 	"github.com/grafana/xk6-disruptor/pkg/kubernetes/helpers"
+	"github.com/grafana/xk6-disruptor/pkg/types/intstr"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// DefaultTargetPort defines default target port if not specified in Fault
-const DefaultTargetPort = 80
-
 // ErrSelectorNoPods is returned by NewPodDisruptor when the selector passed to it does not match any pod in the
 // cluster.
 var ErrSelectorNoPods = errors.New("no pods found matching selector")
+
+// DefaultTargetPort defines the default value for a target HTTP
+var DefaultTargetPort = intstr.FromInt(80) //nolint:gochecknoglobals
 
 // PodDisruptor defines the types of faults that can be injected in a Pod
 type PodDisruptor interface {
@@ -155,8 +156,9 @@ func (d *podDisruptor) InjectHTTPFaults(
 	duration time.Duration,
 	options HTTPDisruptionOptions,
 ) error {
+	// Handle default port mapping
 	// TODO: make port mandatory instead of using a default
-	if fault.Port == 0 {
+	if fault.Port == intstr.NullValue || (fault.Port.IsInt() && fault.Port.Int32() == 0) {
 		fault.Port = DefaultTargetPort
 	}
 

--- a/pkg/disruptors/protocol.go
+++ b/pkg/disruptors/protocol.go
@@ -3,6 +3,8 @@ package disruptors
 import (
 	"context"
 	"time"
+
+	"github.com/grafana/xk6-disruptor/pkg/types/intstr"
 )
 
 // ProtocolFaultInjector defines the methods for injecting protocol faults
@@ -30,7 +32,7 @@ type GrpcDisruptionOptions struct {
 // HTTPFault specifies a fault to be injected in http requests
 type HTTPFault struct {
 	// port the disruptions will be applied to
-	Port uint
+	Port intstr.IntOrString
 	// Average delay introduced to requests
 	AverageDelay time.Duration `js:"averageDelay"`
 	// Variation in the delay (with respect of the average delay)
@@ -48,7 +50,7 @@ type HTTPFault struct {
 // GrpcFault specifies a fault to be injected in grpc requests
 type GrpcFault struct {
 	// port the disruptions will be applied to
-	Port uint
+	Port intstr.IntOrString
 	// Average delay introduced to requests
 	AverageDelay time.Duration `js:"averageDelay"`
 	// Variation in the delay (with respect of the average delay)

--- a/pkg/disruptors/service.go
+++ b/pkg/disruptors/service.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/xk6-disruptor/pkg/kubernetes"
 	"github.com/grafana/xk6-disruptor/pkg/kubernetes/helpers"
+	"github.com/grafana/xk6-disruptor/pkg/utils"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -83,9 +84,16 @@ func (d *serviceDisruptor) InjectHTTPFaults(
 	duration time.Duration,
 	options HTTPDisruptionOptions,
 ) error {
-	command := ServiceHTTPFaultCommand{
-		service:  d.service,
-		fault:    fault,
+	// Map service port to a target pod port
+	port, err := utils.GetTargetPort(d.service, fault.Port)
+	if err != nil {
+		return err
+	}
+	podFault := fault
+	podFault.Port = port
+
+	command := PodHTTPFaultCommand{
+		fault:    podFault,
 		duration: duration,
 		options:  options,
 	}
@@ -105,8 +113,15 @@ func (d *serviceDisruptor) InjectGrpcFaults(
 	duration time.Duration,
 	options GrpcDisruptionOptions,
 ) error {
-	command := ServiceGrpcFaultCommand{
-		service:  d.service,
+	// Map service port to a target pod port
+	port, err := utils.GetTargetPort(d.service, fault.Port)
+	if err != nil {
+		return err
+	}
+	podFault := fault
+	podFault.Port = port
+
+	command := PodGrpcFaultCommand{
 		fault:    fault,
 		duration: duration,
 		options:  options,

--- a/pkg/types/intstr/intstr.go
+++ b/pkg/types/intstr/intstr.go
@@ -1,0 +1,73 @@
+// Package intstr implements custom types
+package intstr
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// ValueType defines the type of a IntOrString value
+type ValueType int
+
+const (
+	// IntValue is a IntOrString that represents an integer value
+	IntValue ValueType = iota
+	// StringValue is a IntOrString 	that represents a string value
+	StringValue
+)
+
+// IntOrString holds a value that can be either a string or a int
+type IntOrString string
+
+// NullValue is an empty IntOrString value
+const NullValue = IntOrString("")
+
+// Type returns the ValueType of a IntOrString value
+func (value IntOrString) Type() ValueType {
+	if _, err := strconv.Atoi(string(value)); err == nil {
+		return IntValue
+	}
+	return StringValue
+}
+
+// IsInt returns true if the value is an integer
+func (value IntOrString) IsInt() bool {
+	_, err := strconv.Atoi(string(value))
+	return err == nil
+}
+
+
+// Int32 returns the value of the IntOrString as an int32.
+// If the current value is not an string, 0 is returned
+func (value IntOrString) Int32() int32 {
+	int64Value, err := strconv.ParseInt(string(value), 10, 32)
+	if err != nil {
+		panic(fmt.Errorf("invalid int32 value %s", value))
+	}
+
+	return int32(int64Value)
+}
+
+
+// Str returns the value of the IntOrString as a string.
+func (value IntOrString) Str() string {
+	return string(value)
+}
+
+// FromInt return a IntOrString from a int
+func FromInt(value int) IntOrString {
+	strValue := fmt.Sprintf("%d", value)
+	return IntOrString(strValue)
+}
+
+// FromInt32 return a IntOrString from a int32
+func FromInt32(value int32) IntOrString {
+	strValue := fmt.Sprintf("%d", value)
+	return IntOrString(strValue)
+}
+
+
+// FromString return a IntOrString from a string
+func FromString(value string) IntOrString {
+	return IntOrString(value)
+}

--- a/pkg/types/intstr/intstr.go
+++ b/pkg/types/intstr/intstr.go
@@ -36,7 +36,6 @@ func (value IntOrString) IsInt() bool {
 	return err == nil
 }
 
-
 // Int32 returns the value of the IntOrString as an int32.
 // If the current value is not an string, 0 is returned
 func (value IntOrString) Int32() int32 {
@@ -47,7 +46,6 @@ func (value IntOrString) Int32() int32 {
 
 	return int32(int64Value)
 }
-
 
 // Str returns the value of the IntOrString as a string.
 func (value IntOrString) Str() string {
@@ -65,7 +63,6 @@ func FromInt32(value int32) IntOrString {
 	strValue := fmt.Sprintf("%d", value)
 	return IntOrString(strValue)
 }
-
 
 // FromString return a IntOrString from a string
 func FromString(value string) IntOrString {

--- a/pkg/types/intstr/intstr_test.go
+++ b/pkg/types/intstr/intstr_test.go
@@ -1,0 +1,132 @@
+package intstr
+
+import (
+	"testing"
+)
+
+func Test_IntStrFrom(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		title       string
+		value       interface{}
+		function    func(interface{}) interface{}
+		expected    interface{}
+		shouldPanic bool
+	}{
+		{
+			title: "fromString string value",
+			value: "uno",
+			function: func(value interface{}) interface{} {
+				strValue, _ := value.(string)
+				return FromString(strValue)
+			},
+			expected: IntOrString("uno"),
+		},
+		{
+			title: "fromString numeric value",
+			value: "1",
+			function: func(value interface{}) interface{} {
+				strValue, _ := value.(string)
+				return FromString(strValue)
+			},
+			expected: IntOrString("1"),
+		},
+		{
+			title: "fromInt32",
+			value: int32(1),
+			function: func(value interface{}) interface{} {
+				int32Value, _ := value.(int32)
+				return FromInt32(int32Value)
+			},
+			expected: IntOrString("1"),
+		},
+		{
+			title: "Int32",
+			value: IntOrString("1"),
+			function: func(value interface{}) interface{} {
+				intOrStrValue, _ := value.(IntOrString)
+				return intOrStrValue.Int32()
+			},
+			expected: int32(1),
+		},
+		{
+			title: "Int32 overflow",
+			value: IntOrString("9223372036854775807"),
+			function: func(value interface{}) interface{} {
+				intOrStrValue, _ := value.(IntOrString)
+				return intOrStrValue.Int32()
+			},
+			expected:    nil,
+			shouldPanic: true,
+		},
+		{
+			title: "Int32 form string value",
+			value: IntOrString("uno"),
+			function: func(value interface{}) interface{} {
+				intOrStrValue, _ := value.(IntOrString)
+				return intOrStrValue.Int32()
+			},
+			expected:    nil,
+			shouldPanic: true,
+		},
+		{
+			title: "Int32 form nul value",
+			value: IntOrString(""),
+			function: func(value interface{}) interface{} {
+				intOrStrValue, _ := value.(IntOrString)
+				return intOrStrValue.Int32()
+			},
+			expected:    nil,
+			shouldPanic: true,
+		},
+		{
+			title: "String form string",
+			value: IntOrString("uno"),
+			function: func(value interface{}) interface{} {
+				intOrStrValue, _ := value.(IntOrString)
+				return intOrStrValue.Str()
+			},
+			expected:    "uno",
+			shouldPanic: false,
+		},
+		{
+			title: "String form nul value",
+			value: IntOrString(""),
+			function: func(value interface{}) interface{} {
+				intOrStrValue, _ := value.(IntOrString)
+				return intOrStrValue.Str()
+			},
+			expected:    "",
+			shouldPanic: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.title, func(t *testing.T) {
+			t.Parallel()
+
+			var panicked interface{}
+			defer func() {
+				panicked = recover()
+				if panicked != nil && !tc.shouldPanic {
+					t.Fatalf("panicked %v", panicked)
+				}
+			}()
+
+			// if this conversion panics, the defer function checks if this is normal
+			value := tc.function(tc.value)
+
+			if panicked == nil && tc.shouldPanic {
+				t.Fatal("should had panicked")
+			}
+
+			// if conversion should panic expected value is undefined, so don't assert it
+			if value != tc.expected {
+				t.Fatalf("expected %s got %s", tc.expected, value)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description

Change the way port mapping is managed in service fault injection to allow reusing the pod injection logic.

Fixes https://github.com/grafana/xk6-disruptor/issues/261 (no longer required)
# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works.   
- [X] I have run linter locally (`make lint`) and all checks pass.
- [X] I have run tests locally (`make test`) and all tests pass.
- [X] I have run relevant integration test locally (`make integration-xxx` for affected packages)
- [X] I have run relevant e2e test locally (`make e2e-xxx` for `disruptors`, or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
