### PR TITLE
Pod termination fault

### DIFF
--- a/e2e/disruptors/pod_e2e_test.go
+++ b/e2e/disruptors/pod_e2e_test.go
@@ -314,7 +314,7 @@ func Test_PodDisruptor(t *testing.T) {
 		}
 
 		fault := disruptors.TerminatePodsFault{
-			Count:   1,
+			Count:   intstr.FromInt32(1),
 			Timeout: 10 * time.Second,
 		}
 
@@ -323,8 +323,8 @@ func Test_PodDisruptor(t *testing.T) {
 			t.Fatalf("terminating pods: %v", err)
 		}
 
-		if len(terminated) != fault.Count {
-			t.Fatalf("Invalid number of pods deleted. Expected %d got %d", fault.Count, len(terminated))
+		if len(terminated) != int(fault.Count.Int32()) {
+			t.Fatalf("Invalid number of pods deleted. Expected %d got %d", fault.Count.Int32(), len(terminated))
 		}
 
 		for _, pod := range terminated {

--- a/e2e/disruptors/pod_e2e_test.go
+++ b/e2e/disruptors/pod_e2e_test.go
@@ -313,7 +313,7 @@ func Test_PodDisruptor(t *testing.T) {
 			t.Fatalf("No pods matched the selector")
 		}
 
-		fault := disruptors.TerminatePodsFault{
+		fault := disruptors.PodTerminationFault{
 			Count:   intstr.FromInt32(1),
 			Timeout: 10 * time.Second,
 		}

--- a/e2e/disruptors/pod_e2e_test.go
+++ b/e2e/disruptors/pod_e2e_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/grafana/xk6-disruptor/pkg/types/intstr"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sintstr "k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/grafana/xk6-disruptor/pkg/disruptors"
@@ -55,22 +57,24 @@ func Test_PodDisruptor(t *testing.T) {
 		return
 	}
 
-	t.Run("Test fault injection", func(t *testing.T) {
+	t.Run("Protocol fault injection", func(t *testing.T) {
 		t.Parallel()
 
 		testCases := []struct {
 			title    string
 			pod      corev1.Pod
+			replicas int
 			service  corev1.Service
 			port     int
 			injector func(d disruptors.PodDisruptor) error
 			check    checks.Check
 		}{
 			{
-				title:   "Inject Http error 500",
-				pod:     fixtures.BuildHttpbinPod(),
-				service: fixtures.BuildHttpbinService(),
-				port:    80,
+				title:    "Inject Http error 500",
+				pod:      fixtures.BuildHttpbinPod(),
+				replicas: 1,
+				service:  fixtures.BuildHttpbinService(),
+				port:     80,
 				injector: func(d disruptors.PodDisruptor) error {
 					fault := disruptors.HTTPFault{
 						Port:      intstr.FromInt32(80),
@@ -93,10 +97,11 @@ func Test_PodDisruptor(t *testing.T) {
 				},
 			},
 			{
-				title:   "Inject Grpc error",
-				pod:     fixtures.BuildGrpcpbinPod(),
-				service: fixtures.BuildGrpcbinService(),
-				port:    9000,
+				title:    "Inject Grpc error",
+				pod:      fixtures.BuildGrpcpbinPod(),
+				replicas: 1,
+				service:  fixtures.BuildGrpcbinService(),
+				port:     9000,
 				injector: func(d disruptors.PodDisruptor) error {
 					fault := disruptors.GrpcFault{
 						Port:       intstr.FromInt32(9000),
@@ -136,6 +141,7 @@ func Test_PodDisruptor(t *testing.T) {
 					k8s,
 					namespace,
 					tc.pod,
+					tc.replicas,
 					tc.service,
 					k8sintstr.FromInt(tc.port),
 					30*time.Second,
@@ -197,7 +203,8 @@ func Test_PodDisruptor(t *testing.T) {
 						t.Fatalf("creating kubectl client from kubeconfig: %v", err)
 					}
 
-					port, err := kc.ForwardPodPort(ctx, namespace, tc.pod.Name, uint(tc.port))
+					// connect via port forwarding to the first pod in the pod set
+					port, err := kc.ForwardPodPort(ctx, namespace, tc.pod.Name+"-0", uint(tc.port))
 					if err != nil {
 						t.Fatalf("forwarding port from %s/%s: %v", namespace, tc.pod.Name, err)
 					}
@@ -221,11 +228,11 @@ func Test_PodDisruptor(t *testing.T) {
 		}
 
 		service := fixtures.BuildHttpbinService()
-
 		err = deploy.ExposeApp(
 			k8s,
 			namespace,
 			fixtures.BuildHttpbinPod(),
+			1,
 			service,
 			k8sintstr.FromInt(80),
 			30*time.Second,
@@ -265,10 +272,70 @@ func Test_PodDisruptor(t *testing.T) {
 			t.Fatalf("disruptor did not return an error")
 		}
 
-		// It is not possible to use errors.Is here, as ErrNoRequests is returned inside the agent pod. The controller
-		// only sees the error message printed to stderr.
+		// It is not possible to use errors.Is here, as ErrNoRequests is returned inside the agent pod.
+		// The controller only sees the error message printed to stderr.
 		if !strings.Contains(err.Error(), protocol.ErrNoRequests.Error()) {
 			t.Fatalf("expected ErrNoRequests, got: %v", err)
+		}
+	})
+
+	t.Run("Terminate Pod", func(t *testing.T) {
+		t.Parallel()
+
+		namespace, err := namespace.CreateTestNamespace(context.TODO(), t, k8s.Client())
+		if err != nil {
+			t.Fatalf("failed to create test namespace: %v", err)
+		}
+
+		err = deploy.RunPodSet(
+			k8s,
+			namespace,
+			fixtures.BuildHttpbinPod(),
+			3,
+			30*time.Second,
+		)
+		if err != nil {
+			t.Fatalf("starting pod replicas %v", err)
+		}
+
+		// create pod disruptor that will select all pods
+		selector := disruptors.PodSelector{
+			Namespace: namespace,
+		}
+		options := disruptors.PodDisruptorOptions{}
+		disruptor, err := disruptors.NewPodDisruptor(context.TODO(), k8s, selector, options)
+		if err != nil {
+			t.Fatalf("creating disruptor: %v", err)
+		}
+
+		targets, _ := disruptor.Targets(context.TODO())
+		if len(targets) == 0 {
+			t.Fatalf("No pods matched the selector")
+		}
+
+		fault := disruptors.TerminatePodsFault{
+			Count:   1,
+			Timeout: 10 * time.Second,
+		}
+
+		terminated, err := disruptor.TerminatePods(context.TODO(), fault)
+		if err != nil {
+			t.Fatalf("terminating pods: %v", err)
+		}
+
+		if len(terminated) != fault.Count {
+			t.Fatalf("Invalid number of pods deleted. Expected %d got %d", fault.Count, len(terminated))
+		}
+
+		for _, pod := range terminated {
+			_, err = k8s.Client().CoreV1().Pods(namespace).Get(context.TODO(), pod, metav1.GetOptions{})
+			if !errors.IsNotFound(err) {
+				if err == nil {
+					t.Fatalf("pod '%s/%s' not deleted", namespace, pod)
+				}
+
+				t.Fatalf("failed %v", err)
+			}
 		}
 	})
 }

--- a/e2e/disruptors/service_e2e_test.go
+++ b/e2e/disruptors/service_e2e_test.go
@@ -186,7 +186,7 @@ func Test_ServiceDisruptor(t *testing.T) {
 		}
 
 		fault := disruptors.TerminatePodsFault{
-			Count:   1,
+			Count:   intstr.FromInt32(1),
 			Timeout: 10 * time.Second,
 		}
 
@@ -195,8 +195,8 @@ func Test_ServiceDisruptor(t *testing.T) {
 			t.Fatalf("terminating pods: %v", err)
 		}
 
-		if len(terminated) != fault.Count {
-			t.Fatalf("Invalid number of pods deleted. Expected %d got %d", fault.Count, len(terminated))
+		if len(terminated) != int(fault.Count.Int32()) {
+			t.Fatalf("Invalid number of pods deleted. Expected %d got %d", fault.Count.Int32(), len(terminated))
 		}
 
 		for _, pod := range terminated {

--- a/e2e/disruptors/service_e2e_test.go
+++ b/e2e/disruptors/service_e2e_test.go
@@ -185,7 +185,7 @@ func Test_ServiceDisruptor(t *testing.T) {
 			t.Fatalf("No pods matched the selector")
 		}
 
-		fault := disruptors.TerminatePodsFault{
+		fault := disruptors.PodTerminationFault{
 			Count:   intstr.FromInt32(1),
 			Timeout: 10 * time.Second,
 		}

--- a/e2e/disruptors/service_e2e_test.go
+++ b/e2e/disruptors/service_e2e_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sintstr "k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/grafana/xk6-disruptor/pkg/disruptors"
@@ -54,16 +56,18 @@ func Test_ServiceDisruptor(t *testing.T) {
 		testCases := []struct {
 			title    string
 			pod      corev1.Pod
+			replicas int
 			service  corev1.Service
 			port     int
 			injector func(d disruptors.ServiceDisruptor) error
 			check    checks.Check
 		}{
 			{
-				title:   "Inject Http error 500",
-				pod:     fixtures.BuildHttpbinPod(),
-				service: fixtures.BuildHttpbinService(),
-				port:    80,
+				title:    "Inject Http error 500",
+				pod:      fixtures.BuildHttpbinPod(),
+				replicas: 1,
+				service:  fixtures.BuildHttpbinService(),
+				port:     80,
 				injector: func(d disruptors.ServiceDisruptor) error {
 					fault := disruptors.HTTPFault{
 						Port:      intstr.FromInt32(80),
@@ -100,6 +104,7 @@ func Test_ServiceDisruptor(t *testing.T) {
 					k8s,
 					namespace,
 					tc.pod,
+					1,
 					tc.service,
 					k8sintstr.FromInt(tc.port),
 					30*time.Second,
@@ -143,6 +148,66 @@ func Test_ServiceDisruptor(t *testing.T) {
 					return
 				}
 			})
+		}
+	})
+
+	t.Run("Terminate Pod", func(t *testing.T) {
+		t.Parallel()
+
+		namespace, err := namespace.CreateTestNamespace(context.TODO(), t, k8s.Client())
+		if err != nil {
+			t.Fatalf("failed to create test namespace: %v", err)
+		}
+
+		service := fixtures.BuildHttpbinService()
+		err = deploy.ExposeApp(
+			k8s,
+			namespace,
+			fixtures.BuildHttpbinPod(),
+			3,
+			service,
+			k8sintstr.FromInt(80),
+			30*time.Second,
+		)
+		if err != nil {
+			t.Fatalf("starting pod replicas %v", err)
+		}
+
+		// create pod disruptor that will select all pods
+		options := disruptors.ServiceDisruptorOptions{}
+		disruptor, err := disruptors.NewServiceDisruptor(context.TODO(), k8s, service.Name, namespace, options)
+		if err != nil {
+			t.Fatalf("creating disruptor: %v", err)
+		}
+
+		targets, _ := disruptor.Targets(context.TODO())
+		if len(targets) == 0 {
+			t.Fatalf("No pods matched the selector")
+		}
+
+		fault := disruptors.TerminatePodsFault{
+			Count:   1,
+			Timeout: 10 * time.Second,
+		}
+
+		terminated, err := disruptor.TerminatePods(context.TODO(), fault)
+		if err != nil {
+			t.Fatalf("terminating pods: %v", err)
+		}
+
+		if len(terminated) != fault.Count {
+			t.Fatalf("Invalid number of pods deleted. Expected %d got %d", fault.Count, len(terminated))
+		}
+
+		for _, pod := range terminated {
+			_, err = k8s.Client().CoreV1().Pods(namespace).Get(context.TODO(), pod, metav1.GetOptions{})
+			if !errors.IsNotFound(err) {
+				if err == nil {
+					t.Fatalf("pod '%s/%s' not deleted", namespace, pod)
+				}
+
+				t.Fatalf("failed %v", err)
+			}
 		}
 	})
 }

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -428,6 +428,53 @@ func Test_JsPodDisruptor(t *testing.T) {
 			`,
 			expectError: true,
 		},
+		{
+			description: "Terminate Pods (integer count)",
+			script: `
+			const fault = {
+				count: 1
+			}
+
+			d.terminatePods(fault)
+			`,
+			expectError: false,
+		},
+		{
+			description: "Terminate Pods (percentage count)",
+			script: `
+			const fault = {
+				count: '100%'
+			}
+
+			d.terminatePods(fault)
+			`,
+			expectError: false,
+		},
+		{
+			description: "Terminate Pods (invalid percentage count)",
+			script: `
+			const fault = {
+				count: '100'
+			}
+
+			d.terminatePods(fault)
+			`,
+			expectError: true,
+		},
+		{
+			description: "Terminate Pods (missing argument)",
+			script: `
+			d.terminatePods()
+			`,
+			expectError: true,
+		},
+		{
+			description: "Terminate Pods (empty argument)",
+			script: `
+			d.terminatePods({})
+			`,
+			expectError: true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/disruptors/controller.go
+++ b/pkg/disruptors/controller.go
@@ -66,16 +66,6 @@ func (c *PodController) Visit(ctx context.Context, visitor PodVisitor) error {
 	}
 }
 
-// Targets return the name of the targets
-func (c *PodController) Targets(_ context.Context) ([]string, error) {
-	names := []string{}
-	for _, pod := range c.targets {
-		names = append(names, pod.Name)
-	}
-
-	return names, nil
-}
-
 // VisitCommands contains the commands to be executed when visiting a pod
 type VisitCommands struct {
 	Exec    []string

--- a/pkg/disruptors/pod.go
+++ b/pkg/disruptors/pod.go
@@ -12,7 +12,9 @@ import (
 	"github.com/grafana/xk6-disruptor/pkg/kubernetes"
 	"github.com/grafana/xk6-disruptor/pkg/kubernetes/helpers"
 	"github.com/grafana/xk6-disruptor/pkg/types/intstr"
+	"github.com/grafana/xk6-disruptor/pkg/utils"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -38,9 +40,9 @@ type PodDisruptorOptions struct {
 
 // podDisruptor is an instance of a PodDisruptor that uses a PodController to interact with target pods
 type podDisruptor struct {
-	helper     helpers.PodHelper
-	options    PodDisruptorOptions
-	controller *PodController
+	helper  helpers.PodHelper
+	options PodDisruptorOptions
+	targets []corev1.Pod
 }
 
 // PodSelector defines the criteria for selecting a pod for disruption
@@ -136,17 +138,15 @@ func NewPodDisruptor(
 		return nil, fmt.Errorf("finding pods matching '%s': %w", selector, ErrSelectorNoPods)
 	}
 
-	controller := NewPodController(targets)
-
 	return &podDisruptor{
-		helper:     helper,
-		options:    options,
-		controller: controller,
+		helper:  helper,
+		options: options,
+		targets: targets,
 	}, nil
 }
 
-func (d *podDisruptor) Targets(ctx context.Context) ([]string, error) {
-	return d.controller.Targets(ctx)
+func (d *podDisruptor) Targets(_ context.Context) ([]string, error) {
+	return utils.PodNames(d.targets), nil
 }
 
 // InjectHTTPFault injects faults in the http requests sent to the disruptor's targets
@@ -174,7 +174,9 @@ func (d *podDisruptor) InjectHTTPFaults(
 		command,
 	)
 
-	return d.controller.Visit(ctx, visitor)
+	controller := NewPodController(d.targets)
+
+	return controller.Visit(ctx, visitor)
 }
 
 // InjectGrpcFaults injects faults in the grpc requests sent to the disruptor's targets
@@ -196,5 +198,7 @@ func (d *podDisruptor) InjectGrpcFaults(
 		command,
 	)
 
-	return d.controller.Visit(ctx, visitor)
+	controller := NewPodController(d.targets)
+
+	return controller.Visit(ctx, visitor)
 }

--- a/pkg/disruptors/pod.go
+++ b/pkg/disruptors/pod.go
@@ -207,7 +207,7 @@ func (d *podDisruptor) InjectGrpcFaults(
 // TerminatePods terminates a subset of the target pods of the disruptor
 func (d *podDisruptor) TerminatePods(
 	ctx context.Context,
-	fault TerminatePodsFault,
+	fault PodTerminationFault,
 ) ([]string, error) {
 	targets, err := utils.Sample(d.targets, fault.Count)
 	if err != nil {

--- a/pkg/disruptors/service.go
+++ b/pkg/disruptors/service.go
@@ -146,7 +146,7 @@ func (d *serviceDisruptor) Targets(_ context.Context) ([]string, error) {
 // TerminatePods terminates a subset of the target pods of the disruptor
 func (d *serviceDisruptor) TerminatePods(
 	ctx context.Context,
-	fault TerminatePodsFault,
+	fault PodTerminationFault,
 ) ([]string, error) {
 	targets, err := utils.Sample(d.targets, fault.Count)
 	if err != nil {

--- a/pkg/disruptors/terminate.go
+++ b/pkg/disruptors/terminate.go
@@ -1,0 +1,38 @@
+package disruptors
+
+import (
+	"context"
+	"time"
+
+	"github.com/grafana/xk6-disruptor/pkg/kubernetes/helpers"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// PodTerminationVisitor defines a Visitor that terminates its target pod
+type PodTerminationVisitor struct {
+	helper  helpers.PodHelper
+	timeout time.Duration
+}
+
+// Visit executes a Terminate action on the target Pod
+func (c PodTerminationVisitor) Visit(ctx context.Context, pod corev1.Pod) error {
+	if c.timeout == 0 {
+		c.timeout = 10 * time.Second
+	}
+	return c.helper.Terminate(ctx, pod.Name, c.timeout)
+}
+
+// PodFaultInjector defines methods for injecting faults into Pods
+type PodFaultInjector interface {
+	// Terminates a set of pods. Returns the list of pods affected. If any of the target pods
+	// is not terminated after the timeout defined in the TerminatePodsFault, an error is returned
+	TerminatePods(context.Context, TerminatePodsFault) ([]string, error)
+}
+
+// TerminatePodsFault specifies a fault that will terminate a set of pods
+type TerminatePodsFault struct {
+	// Count indicates how many pods to terminate
+	Count int
+	// Timeout specifies the maximum time to wait for a pod to terminate
+	Timeout time.Duration
+}

--- a/pkg/disruptors/terminate.go
+++ b/pkg/disruptors/terminate.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/grafana/xk6-disruptor/pkg/kubernetes/helpers"
+	"github.com/grafana/xk6-disruptor/pkg/types/intstr"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -31,8 +32,8 @@ type PodFaultInjector interface {
 
 // TerminatePodsFault specifies a fault that will terminate a set of pods
 type TerminatePodsFault struct {
-	// Count indicates how many pods to terminate
-	Count int
+	// Count indicates how many pods to terminate. Can be a number or a percentage or targets
+	Count intstr.IntOrString
 	// Timeout specifies the maximum time to wait for a pod to terminate
 	Timeout time.Duration
 }

--- a/pkg/disruptors/terminate.go
+++ b/pkg/disruptors/terminate.go
@@ -27,11 +27,11 @@ func (c PodTerminationVisitor) Visit(ctx context.Context, pod corev1.Pod) error 
 type PodFaultInjector interface {
 	// Terminates a set of pods. Returns the list of pods affected. If any of the target pods
 	// is not terminated after the timeout defined in the TerminatePodsFault, an error is returned
-	TerminatePods(context.Context, TerminatePodsFault) ([]string, error)
+	TerminatePods(context.Context, PodTerminationFault) ([]string, error)
 }
 
-// TerminatePodsFault specifies a fault that will terminate a set of pods
-type TerminatePodsFault struct {
+// PodTerminationFault specifies a fault that will terminate a set of pods
+type PodTerminationFault struct {
 	// Count indicates how many pods to terminate. Can be a number or a percentage or targets
 	Count intstr.IntOrString
 	// Timeout specifies the maximum time to wait for a pod to terminate

--- a/pkg/types/intstr/intstr.go
+++ b/pkg/types/intstr/intstr.go
@@ -4,6 +4,7 @@ package intstr
 import (
 	"fmt"
 	"strconv"
+	"strings"
 )
 
 // ValueType defines the type of a IntOrString value
@@ -33,6 +34,24 @@ func (value IntOrString) Type() ValueType {
 // IsInt returns true if the value is an integer
 func (value IntOrString) IsInt() bool {
 	return value.Type() == ValueTypeInt
+}
+
+// AsPercentage return the value of a string transformed in a percentage and reports if
+// this conversion was possible. '10%' return 10 and true, while "10", "foo" return 0 and false.
+func (value IntOrString) AsPercentage() (int32, bool) {
+	if value.Type() == ValueTypeInt {
+		return 0, false
+	}
+	prefix, suffix, found := strings.Cut(value.Str(), "%")
+	if !found || suffix != "" {
+		return 0, false
+	}
+
+	if !IntOrString(prefix).IsInt() {
+		return 0, false
+	}
+
+	return IntOrString(prefix).Int32(), true
 }
 
 // IsZero checks if the IntOrString value is an integer 0

--- a/pkg/types/intstr/intstr_test.go
+++ b/pkg/types/intstr/intstr_test.go
@@ -129,3 +129,95 @@ func Test_IntStrFrom(t *testing.T) {
 		})
 	}
 }
+
+func Test_AsPercentage(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		title       string
+		value       IntOrString
+		expect      int32
+		expectError bool
+	}{
+		{
+			title:       "percentage value",
+			value:       IntOrString("10%"),
+			expect:      10,
+			expectError: false,
+		},
+		{
+			title:       "float percentage value",
+			value:       IntOrString("10.5%"),
+			expect:      10,
+			expectError: true,
+		},
+		{
+			title:       "non int percentage value",
+			value:       IntOrString("foo%"),
+			expect:      10,
+			expectError: true,
+		},
+		{
+			title:       "int value",
+			value:       IntOrString("10"),
+			expect:      0,
+			expectError: true,
+		},
+		{
+			title:       "invalid value",
+			value:       IntOrString("foo"),
+			expect:      0,
+			expectError: true,
+		},
+		{
+			title:       "only percentage",
+			value:       IntOrString("%"),
+			expect:      0,
+			expectError: true,
+		},
+		{
+			title:       "extra percentage",
+			value:       IntOrString("10%%"),
+			expect:      0,
+			expectError: true,
+		},
+		{
+			title:       "leading percentage",
+			value:       IntOrString("%10"),
+			expect:      0,
+			expectError: true,
+		},
+		{
+			title:       "nul value",
+			value:       NullValue,
+			expect:      0,
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(tc.title, func(t *testing.T) {
+			t.Parallel()
+
+			value, ok := tc.value.AsPercentage()
+
+			if !ok && tc.expectError {
+				return
+			}
+
+			if !ok && !tc.expectError {
+				t.Fatal("failed")
+			}
+
+			if ok && tc.expectError {
+				t.Fatalf("should have failed")
+			}
+
+			if value != tc.expect {
+				t.Fatalf("expected %d got %d", tc.expect, value)
+			}
+		})
+	}
+}

--- a/pkg/utils/kubernetes.go
+++ b/pkg/utils/kubernetes.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/grafana/xk6-disruptor/pkg/types/intstr"
 	corev1 "k8s.io/api/core/v1"
@@ -77,11 +78,29 @@ func PodNames(pods []corev1.Pod) []string {
 	return names
 }
 
-// Sample a subset of the given list of Pods
-func Sample(pods []corev1.Pod, count int) ([]corev1.Pod, error) {
-	if count > len(pods) {
-		return nil, fmt.Errorf("cannot sample %d pods out of a total of %d", count, len(pods))
+// Sample a subset of the given list of Pods. The count is defined as a int or a string representing a percentage.
+// If the count is a percentage and there are no enough elements in the pod list, the number is rounded up.
+// If the list is not empty, at least one element is returned
+// For example 25% of a list of 2 pods will return one pod.
+func Sample(pods []corev1.Pod, count intstr.IntOrString) ([]corev1.Pod, error) {
+	var sampleSize int
+	if count.IsInt() {
+		sampleSize = int(count.Int32())
+	} else {
+		percentage, ok := count.AsPercentage()
+		if !ok {
+			return nil, fmt.Errorf("count is not a valid percentage: %s", count)
+		}
+
+		if percentage == 0 {
+			return nil, nil
+		}
+
+		sampleSize = int(math.Max(1, math.Round(float64(len(pods)*int(percentage))/100)))
 	}
 
-	return pods[:count], nil
+	if sampleSize > len(pods) {
+		return nil, fmt.Errorf("cannot sample %d pods out of a total of %d", sampleSize, len(pods))
+	}
+	return pods[:sampleSize], nil
 }

--- a/pkg/utils/kubernetes.go
+++ b/pkg/utils/kubernetes.go
@@ -66,3 +66,13 @@ func PodIP(pod corev1.Pod) (string, error) {
 
 	return "", fmt.Errorf("pod %s/%s does not have an IP address", pod.Namespace, pod.Name)
 }
+
+// PodNames return the name of the pods in a list
+func PodNames(pods []corev1.Pod) []string {
+	names := make([]string, 0, len(pods))
+	for _, pod := range pods {
+		names = append(names, pod.Name)
+	}
+
+	return names
+}

--- a/pkg/utils/kubernetes.go
+++ b/pkg/utils/kubernetes.go
@@ -76,3 +76,12 @@ func PodNames(pods []corev1.Pod) []string {
 
 	return names
 }
+
+// Sample a subset of the given list of Pods
+func Sample(pods []corev1.Pod, count int) ([]corev1.Pod, error) {
+	if count > len(pods) {
+		return nil, fmt.Errorf("cannot sample %d pods out of a total of %d", count, len(pods))
+	}
+
+	return pods[:count], nil
+}


### PR DESCRIPTION
# Description

Introduces the Terminate pod fault. 

Documentation: https://github.com/grafana/k6-docs/pull/1381

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works.   
- [X] I have run linter locally (`make lint`) and all checks pass.
- [X] I have run tests locally (`make test`) and all tests pass.
- [X] I have run relevant integration test locally (`make integration-xxx` for affected packages)
- [X] I have run relevant e2e test locally (`make e2e-xxx` for `disruptors`, or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
