### PR TITLE
Revert core actions to v4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,7 +84,6 @@ jobs:
           name: binaries
           path: dist/
           retention-days: 7
-          overwrite: true
       - name: Export version
         id: export-version
         env:
@@ -136,7 +135,6 @@ jobs:
           path: |
             packaging/*.msi
           retention-days: 7
-          overwrite: true
 
   publish-images:
     runs-on: ubuntu-latest
@@ -207,7 +205,6 @@ jobs:
         with:
           name: binaries
           path: dist
-          merge-multiple: true
       - name: Generate checksum file
         env:
            VERSION: ${{ env.VERSION }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,7 +79,7 @@ jobs:
             tar -zcf dist/$AGENT-${PKG_VERSION}-linux-$ARCH.tar.gz -C build/ $AGENT-linux-$ARCH
           done
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: binaries
           path: dist/
@@ -112,7 +112,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Download binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: binaries
           path: dist
@@ -129,7 +129,7 @@ jobs:
           .\wix311\candle.exe -arch x64 "-dVERSION=$Env:VERSION" xk6disruptor.wxs
           .\wix311\light.exe -ext WixUIExtension -o "$Env:PKGNAME.msi" xk6disruptor.wixobj
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: binaries
           path: |
@@ -153,7 +153,7 @@ jobs:
           echo "PKG_VERSION=${{needs.build-binaries.outputs.pkg_version}}" >> $GITHUB_ENV
           echo "IMAGE_VERSION=${{needs.build-binaries.outputs.image_version}}" >> $GITHUB_ENV
       - name: Download binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: binaries
           path: dist
@@ -201,7 +201,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Download binaries
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v3
         with:
           name: binaries
           path: dist


### PR DESCRIPTION
# Description

Revert https://github.com/grafana/xk6-disruptor/pull/382 and subsequent attempt to fix the issues it introduced when uploading artifacts from multiple jobs in https://github.com/grafana/xk6-disruptor/commit/b8bec0b88f87fcdd244e80bcfa9e7529c53d6754
