### PR TITLE
update release notes for v0.3.11

### DIFF
--- a/releases/v0.3.11.md
+++ b/releases/v0.3.11.md
@@ -4,6 +4,10 @@ This is a patch release that fixes a few bugs and does minor improvements.
 
 - [#370](https://github.com/grafana/xk6-disruptor/pull/370) We have updated our license to AGPL to align with Grafana license policy
 
+## Bug fixes
+
+- [#391](https://github.com/grafana/xk6-disruptor/pull/391) Revert the update of upload/download artifacts actions to v4 due to issues when uploading artifacts from multiple jobs 
+
 ## Internal improvements
 - [#388](https://github.com/grafana/xk6-disruptor/pull/388) Update k6 to v0.49.0
 - [#298](https://github.com/grafana/xk6-disruptor/pull/298) [#376](https://github.com/grafana/xk6-disruptor/pull/376) Update dependencies


### PR DESCRIPTION
Update release notes for v0.3.11 to reflect the revert of #382 that prevented the publication of the release artifacts