### PR TITLE
Remove unneeded testutils usage - package now internal in k6

### DIFF
--- a/disruptor_test.go
+++ b/disruptor_test.go
@@ -14,7 +14,6 @@ import (
 	"go.k6.io/k6/js/modules"
 	"go.k6.io/k6/js/modulestest"
 	"go.k6.io/k6/lib"
-	"go.k6.io/k6/lib/testutils"
 	"go.k6.io/k6/metrics"
 
 	"k8s.io/client-go/kubernetes/fake"
@@ -26,9 +25,6 @@ func testVU() modules.VU {
 	rt.SetFieldNameMapper(common.FieldNameMapper{})
 
 	testLog := logrus.New()
-	testLog.AddHook(&testutils.SimpleLogrusHook{
-		HookedLevels: []logrus.Level{logrus.WarnLevel},
-	})
 	testLog.SetOutput(ioutil.Discard)
 
 	state := &lib.State{


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change including related open issues or other open PRs. -->

<!--- If implementing a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it -->
Fixes # (issue)

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make test`) and all tests pass.
- [ ] I have run relevant integration test locally (`make integration-xxx` for affected packages)
- [ ] I have run relevant e2e test locally (`make e2e-xxx` for `disruptors`, or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
