### PR TITLE
feat(termination): Add `gracePeriod` and `force`

### DIFF
--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -476,6 +476,44 @@ func Test_JsPodDisruptor(t *testing.T) {
 			`,
 			expectError: true,
 		},
+		{
+			description: "Terminate Pods (timeout)",
+			script: `
+			const fault = {
+				timeout: "10s",
+				count: 1
+			}
+
+			d.terminatePods(fault)
+			`,
+			expectError: false,
+		},
+		{
+			description: "Terminate Pods (timeout and grace period)",
+			script: `
+			const fault = {
+				timeout: "10s",
+				gracePeriod: "1s",
+				count: 1,
+			}
+
+			d.terminatePods(fault)
+			`,
+			expectError: false,
+		},
+		{
+			description: "Terminate Pods (force)",
+			script: `
+			const fault = {
+				timeout: "10s",
+				force: true,
+				count: 1,
+			}
+
+			d.terminatePods(fault)
+			`,
+			expectError: false,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/disruptors/pod.go
+++ b/pkg/disruptors/pod.go
@@ -164,7 +164,7 @@ func (d *podDisruptor) TerminatePods(
 
 	controller := NewPodController(targets)
 
-	visitor := PodTerminationVisitor{helper: d.helper, timeout: fault.Timeout}
+	visitor := PodTerminationVisitor{helper: d.helper, timeout: fault.Timeout, gracePeriod: fault.GracePeriod}
 
 	return utils.PodNames(targets), controller.Visit(ctx, visitor)
 }

--- a/pkg/disruptors/service.go
+++ b/pkg/disruptors/service.go
@@ -167,7 +167,7 @@ func (d *serviceDisruptor) TerminatePods(
 
 	controller := NewPodController(targets)
 
-	visitor := PodTerminationVisitor{helper: d.helper, timeout: fault.Timeout}
+	visitor := PodTerminationVisitor{helper: d.helper, timeout: fault.Timeout, gracePeriod: fault.GracePeriod}
 
 	return utils.PodNames(targets), controller.Visit(ctx, visitor)
 }

--- a/pkg/disruptors/terminate.go
+++ b/pkg/disruptors/terminate.go
@@ -11,8 +11,10 @@ import (
 
 // PodTerminationVisitor defines a Visitor that terminates its target pod
 type PodTerminationVisitor struct {
-	helper  helpers.PodHelper
-	timeout time.Duration
+	helper      helpers.PodHelper
+	timeout     time.Duration
+	gracePeriod time.Duration
+	force       bool
 }
 
 // Visit executes a Terminate action on the target Pod
@@ -20,7 +22,7 @@ func (c PodTerminationVisitor) Visit(ctx context.Context, pod corev1.Pod) error 
 	if c.timeout == 0 {
 		c.timeout = 10 * time.Second
 	}
-	return c.helper.Terminate(ctx, pod.Name, c.timeout)
+	return c.helper.Terminate(ctx, pod.Name, c.timeout, c.gracePeriod, c.force)
 }
 
 // PodFaultInjector defines methods for injecting faults into Pods
@@ -34,6 +36,10 @@ type PodFaultInjector interface {
 type PodTerminationFault struct {
 	// Count indicates how many pods to terminate. Can be a number or a percentage or targets
 	Count intstr.IntOrString
-	// Timeout specifies the maximum time to wait for a pod to terminate
+	// Timeout specifies the maximum time to wait for a pod to terminate. After the timeout, the fault injection completes with an error.
 	Timeout time.Duration
+	// GracePeriod specifies the grace period to wait for a pod to terminate. After the grace period, the pod is terminated forcefully. Set to 0 to terminate immediately.
+	GracePeriod time.Duration
+	// Force specifies if the pod should be terminated forcefully. GracePeriod is ignored if Force is true.
+	Force bool
 }


### PR DESCRIPTION
This mirrors the kubectl API and allows to terminate pods ungracefully This is useful for pods that have very graceful and long shutdown proces

# Description

<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change including related open issues or other open PRs. -->

<!--- If implementing a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it -->
Fixes # (issue)

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make test`) and all tests pass.
- [ ] I have run relevant integration test locally (`make integration-xxx` for affected packages)
- [ ] I have run relevant e2e test locally (`make e2e-xxx` for `disruptors`, or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
