### PR TITLE
feat: js api network fault injector

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -158,6 +158,7 @@ type jsPodDisruptor struct {
 	jsDisruptor
 	jsProtocolFaultInjector
 	jsPodFaultInjector
+	jsNetworkFaultInjector
 }
 
 // buildJsPodDisruptor builds a goja object that implements the PodDisruptor API
@@ -182,9 +183,48 @@ func buildJsPodDisruptor(
 			rt:               rt,
 			PodFaultInjector: disruptor,
 		},
+		jsNetworkFaultInjector: jsNetworkFaultInjector{
+			ctx:                  ctx,
+			rt:                   rt,
+			NetworkFaultInjector: disruptor,
+		},
 	}
 
 	return buildObject(rt, d)
+}
+
+// jsNetworkFaultInjector implements methods for injecting network faults
+type jsNetworkFaultInjector struct {
+	ctx context.Context
+	rt  *sobek.Runtime
+	disruptors.NetworkFaultInjector
+}
+
+// InjectNetworkFaults is a proxy method. Validates parameters and delegates to the Network Fault Injector method
+func (p *jsNetworkFaultInjector) InjectNetworkFaults(args ...sobek.Value) {
+	if len(args) < 2 {
+		common.Throw(p.rt, fmt.Errorf("NetworkFault and duration are required"))
+	}
+
+	// NetworkFault is optional. This is to keep the API consistent with the other fault injectors
+	fault := disruptors.NetworkFault{}
+	if !args[0].Equals(sobek.Null()) {
+		err := convertValue(p.rt, args[0], &fault)
+		if err != nil {
+			common.Throw(p.rt, fmt.Errorf("invalid fault argument: %w", err))
+		}
+	}
+
+	var duration time.Duration
+	err := convertValue(p.rt, args[1], &duration)
+	if err != nil {
+		common.Throw(p.rt, fmt.Errorf("invalid duration argument: %w", err))
+	}
+
+	err = p.NetworkFaultInjector.InjectNetworkFaults(p.ctx, fault, duration)
+	if err != nil {
+		common.Throw(p.rt, fmt.Errorf("error injecting fault: %w", err))
+	}
 }
 
 type jsServiceDisruptor struct {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -202,36 +202,20 @@ type jsNetworkFaultInjector struct {
 
 // InjectNetworkFaults is a proxy method. Validates parameters and delegates to the Network Fault Injector method
 func (p *jsNetworkFaultInjector) InjectNetworkFaults(args ...sobek.Value) {
-	if len(args) < 1 {
-		common.Throw(p.rt, fmt.Errorf("duration is required"))
+	if len(args) < 2 {
+		common.Throw(p.rt, fmt.Errorf("NetworkFault and duration are required"))
 	}
 
-	var fault disruptors.NetworkFault
+	fault := disruptors.NetworkFault{}
+	err := convertValue(p.rt, args[0], &fault)
+	if err != nil {
+		common.Throw(p.rt, fmt.Errorf("invalid fault argument: %w", err))
+	}
+
 	var duration time.Duration
-	var err error
-
-	if len(args) == 1 {
-		// Only duration provided, use default NetworkFault
-		if args[0].ExportType().Kind() == reflect.String {
-			fault = disruptors.NetworkFault{}
-			err = convertValue(p.rt, args[0], &duration)
-			if err != nil {
-				common.Throw(p.rt, fmt.Errorf("invalid duration argument: %w", err))
-			}
-		} else {
-			common.Throw(p.rt, fmt.Errorf("duration is required"))
-		}
-	} else {
-		// Both fault and duration provided
-		err = convertValue(p.rt, args[0], &fault)
-		if err != nil {
-			common.Throw(p.rt, fmt.Errorf("invalid fault argument: %w", err))
-		}
-
-		err = convertValue(p.rt, args[1], &duration)
-		if err != nil {
-			common.Throw(p.rt, fmt.Errorf("invalid duration argument: %w", err))
-		}
+	err = convertValue(p.rt, args[1], &duration)
+	if err != nil {
+		common.Throw(p.rt, fmt.Errorf("invalid duration argument: %w", err))
 	}
 
 	err = p.NetworkFaultInjector.InjectNetworkFaults(p.ctx, fault, duration)


### PR DESCRIPTION
# Description

This PR adds network fault injection capabilities to the JavaScript API for the PodDisruptor, enabling users to inject network faults directly from their k6 test scripts.

Sample Script tested locally

```
import { PodDisruptor } from 'k6/x/disruptor';

export default function () {
  // Create disruptor targeting your pods
  const disruptor = new PodDisruptor({
    namespace: 'grpcbin',
    select: { labels: { app: 'grpcbin' } }  // 👈 Change this!
  });

  console.log('Found targets:', disruptor.targets());

  // Test the network fault injection
  console.log('🔥 Injecting network faults...');
  
  // This uses our new API with optional NetworkFault
  disruptor.injectNetworkFaults(null, '30000s');
  
  console.log('✅ Network fault injection started!');
  console.log('💡 Check your pods - network traffic should be disrupted');
```

<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change including related open issues or other open PRs. -->

<!--- If implementing a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it -->


Part of https://github.com/grafana/mimir-squad/issues/3066

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make test`) and all tests pass.
- [ ] I have run relevant integration test locally (`make integration-xxx` for affected packages)
- [ ] I have run relevant e2e test locally (`make e2e-xxx` for `disruptors`, or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
