### PR TITLE
fix: make disruptor-agent for local testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,7 @@ all: build
 agent-image: build-agent
 	docker build --build-arg TARGETARCH=${arch} -t $(agent_image) images/agent
 
-disruptor-image:
-	./build-package.sh -o linux -a ${arch} -v latest -b image/dist/build build
+disruptor-image: build-disruptor
 	docker build --build-arg TARGETARCH=${arch} -t $(image) images/disruptor
 
 echoserver-image:
@@ -27,6 +26,9 @@ build-e2e:
 build-agent:
 	go test ./pkg/agent/...
 	GOOS=linux CGO_ENABLED=0 go build -o images/agent/build/xk6-disruptor-agent-linux-${arch} ./cmd/agent
+
+build-disruptor:
+	./build.sh -o linux -a ${arch}  -b images/disruptor/build
 
 clean:
 	rm -rf image/agent/build build/

--- a/cmd/agent/commands/root.go
+++ b/cmd/agent/commands/root.go
@@ -26,10 +26,10 @@ func NewRootCommand(env runtime.Environment) *RootCommand {
 	rootCmd := buildRootCmd(config)
 	rootCmd.AddCommand(BuildHTTPCmd(env, config))
 	rootCmd.AddCommand(BuildGrpcCmd(env, config))
-	rootCmd.AddCommand(BuildNetworkDropCmd(env, config))
 	rootCmd.AddCommand(BuildTCPDropCmd(env, config))
 	rootCmd.AddCommand(BuildStressCmd(env, config))
 	rootCmd.AddCommand(BuiltCleanupCmd(env))
+	rootCmd.AddCommand(BuildNetworkDropCmd(env, config))
 
 	return &RootCommand{
 		cmd: rootCmd,

--- a/cmd/agent/commands/root.go
+++ b/cmd/agent/commands/root.go
@@ -26,10 +26,10 @@ func NewRootCommand(env runtime.Environment) *RootCommand {
 	rootCmd := buildRootCmd(config)
 	rootCmd.AddCommand(BuildHTTPCmd(env, config))
 	rootCmd.AddCommand(BuildGrpcCmd(env, config))
+	rootCmd.AddCommand(BuildNetworkDropCmd(env, config))
 	rootCmd.AddCommand(BuildTCPDropCmd(env, config))
 	rootCmd.AddCommand(BuildStressCmd(env, config))
 	rootCmd.AddCommand(BuiltCleanupCmd(env))
-	rootCmd.AddCommand(BuildNetworkDropCmd(env, config))
 
 	return &RootCommand{
 		cmd: rootCmd,


### PR DESCRIPTION
# Description

<!--- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->
<!--- List any dependencies that are required for this change including related open issues or other open PRs. -->

<!--- If implementing a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it -->

This should fix the `make disruptor-image` command that is used to generate disruptor image for local testing 
 
![Screenshot 2025-07-10 at 11 57 00](https://github.com/user-attachments/assets/62c61973-bb62-4d96-b4b1-c2fb077d82c9)

# Checklist:

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works.   
- [ ] I have run linter locally (`make lint`) and all checks pass.
- [ ] I have run tests locally (`make test`) and all tests pass.
- [ ] I have run relevant integration test locally (`make integration-xxx` for affected packages)
- [ ] I have run relevant e2e test locally (`make e2e-xxx` for `disruptors`, or `cluster` related changes)
- [ ] Any dependent changes have been merged and published in downstream modules<br>
